### PR TITLE
Add generic trajectory NEB parser with shared utilities

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:

--- a/.github/workflows/ci_prek.yml
+++ b/.github/workflows/ci_prek.yml
@@ -1,0 +1,15 @@
+name: lints
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+on: [push, pull_request]
+jobs:
+  lints:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+    - name: Run precommit
+      run: |
+        uvx prek run -a -vvv

--- a/chemparseplot/parse/converter.py
+++ b/chemparseplot/parse/converter.py
@@ -7,5 +7,10 @@ import numpy as np
 
 
 def np_txt(matched_data):
+    """Convert a matched text block to a numpy array via ``np.loadtxt``.
+
+    ```{versionadded} 0.0.2
+    ```
+    """
     datio = StringIO(matched_data)
     return np.loadtxt(datio)

--- a/chemparseplot/parse/eon/gprd.py
+++ b/chemparseplot/parse/eon/gprd.py
@@ -12,6 +12,8 @@ from ase.io.trajectory import Trajectory
 
 log = logging.getLogger(__name__)
 
+_DOUBLET_MULT = 2
+
 
 class HDF5CalculatorDimerMidpoint(Calculator):
     """ASE calculator reading energy/forces from an HDF5 dimer midpoint group.
@@ -243,7 +245,7 @@ def create_nwchem_trajectory(
     nwchem_path = os.environ["NWCHEM_COMMAND"]
     memory = "2 gb"
     nwchem_kwargs = {
-        "command": f"{nwchem_path} PREFIX.nwi > PREFIX.nwo",
+        "command": f"{nwchem_path} PREFIX.nwi > PREFIX.nwo",  # codespell:ignore nwo
         "memory": memory,
         "scf": {
             "nopen": mult - 1,
@@ -253,7 +255,7 @@ def create_nwchem_trajectory(
         "basis": "3-21G",
         "task": "gradient",
     }
-    if mult == 2:
+    if mult == _DOUBLET_MULT:
         nwchem_kwargs["scf"]["uhf"] = None  # switch to unrestricted calculation
 
     for key in outer_loop_keys:

--- a/chemparseplot/parse/eon/gprd.py
+++ b/chemparseplot/parse/eon/gprd.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import typing
 
@@ -9,8 +10,16 @@ from ase.calculators.calculator import Calculator, all_changes
 from ase.calculators.nwchem import NWChem
 from ase.io.trajectory import Trajectory
 
+log = logging.getLogger(__name__)
+
 
 class HDF5CalculatorDimerMidpoint(Calculator):
+    """ASE calculator reading energy/forces from an HDF5 dimer midpoint group.
+
+    ```{versionadded} 0.0.3
+    ```
+    """
+
     implemented_properties: typing.ClassVar[list[str]] = ["energy", "forces"]
 
     def __init__(self, from_hdf5, natms, **kwargs):
@@ -20,11 +29,16 @@ class HDF5CalculatorDimerMidpoint(Calculator):
         self.natoms = natms
 
     def calculate(
-        self, atoms=None, properties=["energy", "forces"], system_changes=all_changes
+        self,
+        atoms=None,
+        properties=None,
+        system_changes=all_changes,
     ):
+        if properties is None:
+            properties = ["energy", "forces"]
         Calculator.calculate(self, atoms, properties, system_changes)
 
-        # Access energy and gradients directly from the referenced HDF5 object
+        # Access energy and gradients from the referenced HDF5 object
         energy = self.from_hdf5["energy"][0]
         forces = self.from_hdf5["gradients"][: self.natoms * 3].reshape(-1, 3) * -1
 
@@ -34,6 +48,12 @@ class HDF5CalculatorDimerMidpoint(Calculator):
 
 
 class HDF5Calculator(Calculator):
+    """ASE calculator reading energy/forces from an HDF5 group.
+
+    ```{versionadded} 0.0.3
+    ```
+    """
+
     implemented_properties: typing.ClassVar[list[str]] = ["energy", "forces"]
 
     def __init__(self, from_hdf5, **kwargs):
@@ -42,11 +62,16 @@ class HDF5Calculator(Calculator):
         self.from_hdf5 = from_hdf5
 
     def calculate(
-        self, atoms=None, properties=["energy", "forces"], system_changes=all_changes
+        self,
+        atoms=None,
+        properties=None,
+        system_changes=all_changes,
     ):
+        if properties is None:
+            properties = ["energy", "forces"]
         Calculator.calculate(self, atoms, properties, system_changes)
 
-        # Access energy and gradients directly from the referenced HDF5 object
+        # Access energy and gradients from the referenced HDF5 object
         energy = self.from_hdf5["energy"][0]
         forces = self.from_hdf5["gradients"][:].reshape(-1, 3) * -1
 
@@ -55,17 +80,26 @@ class HDF5Calculator(Calculator):
         self.results["forces"] = forces
 
 
-def get_atoms_from_hdf5(template_atoms: ase.Atoms, hdf5_group: h5py.Group) -> ase.Atoms:
-    """
-    Creates an ASE Atoms object from a template and an HDF5 group containing optimization data.
+def get_atoms_from_hdf5(
+    template_atoms: ase.Atoms,
+    hdf5_group: h5py.Group,
+) -> ase.Atoms:
+    """Create an ASE Atoms object from a template and HDF5 group.
+
+    Contains optimization data.
+
+    ```{versionadded} 0.0.3
+    ```
 
     Args:
-        template_atoms (ase.Atoms): The template ASE Atoms object (initial structure).
-        hdf5_group (h5py.Group): The HDF5 group containing 'energy', 'gradients', and 'positions' datasets.
+        template_atoms (ase.Atoms): The template ASE Atoms
+            object (initial structure).
+        hdf5_group (h5py.Group): The HDF5 group containing
+            'energy', 'gradients', and 'positions' datasets.
 
     Returns:
-        ase.Atoms: An ASE Atoms object with positions, energy, and forces from
-        the HDF5 group.
+        ase.Atoms: An ASE Atoms object with positions, energy,
+            and forces from the HDF5 group.
     """
 
     atoms = template_atoms.copy()
@@ -85,6 +119,9 @@ def create_geom_traj_from_hdf5(
     Creates an ASE trajectory file from an HDF5 file containing optimization
     data. This only outputs the geometry steps after the initial rotations.
 
+    ```{versionadded} 0.0.3
+    ```
+
     Generally this is what you want to see for checking the change in geometry
     along the run. There are initial rotations and 2 additional calls (one in
     the beginning and one at the end) which are not accounted for here.
@@ -93,33 +130,38 @@ def create_geom_traj_from_hdf5(
         hdf5_file (str): Path to the HDF5 file.
         output_traj_file (str): Path to the output trajectory file (e.g.,
         'gprd_run.traj').
-        initial_structure_file (str): Path to the file containing the initial structure (e.g., 'pos.con').
-        outer_loop_group_name (str, optional): Name of the group containing
-        outer loop data. Defaults to "outer_loop".
+        initial_structure_file (str): Path to the file containing
+            the initial structure (e.g., 'pos.con').
+        outer_loop_group_name (str, optional): Name of the group
+            containing outer loop data. Defaults to
+            "outer_loop".
     """
 
     try:
         f = h5py.File(hdf5_file, "r")
     except FileNotFoundError:
-        print(f"Error: HDF5 file '{hdf5_file}' not found.")
+        log.error("HDF5 file '%s' not found.", hdf5_file)
         return
     except Exception as e:
-        print(f"An error occurred while opening HDF5 file: {e}")
+        log.error("Error opening HDF5 file: %s", e)
         return
 
     outer_loop_keys = [
         str(x) for x in np.sort([int(x) for x in f[outer_loop_group_name].keys()])
     ]
-    print(f"Available outer loop keys: {outer_loop_keys}")
+    log.info("Available outer loop keys: %s", outer_loop_keys)
 
     try:
         init = aseio.read(initial_structure_file)
     except FileNotFoundError:
-        print(f"Error: Initial structure file '{initial_structure_file}' not found.")
+        log.error(
+            "Initial structure file '%s' not found.",
+            initial_structure_file,
+        )
         f.close()
         return
     except Exception as e:
-        print(f"An error occurred while reading initial structure file: {e}")
+        log.error("Error reading initial structure file: %s", e)
         f.close()
         return
 
@@ -140,13 +182,20 @@ def create_geom_traj_from_hdf5(
 
             traj.write(atoms)
         except KeyError as e:
-            print(f"Skipping key {key} due to missing data: {e}")
+            log.warning(
+                "Skipping key %s due to missing data: %s",
+                key,
+                e,
+            )
         except Exception as e:
-            print(f"An error occurred while processing key {key}: {e}")
+            log.error("Error processing key %s: %s", key, e)
 
     f.close()
     traj.close()
-    print(f"Trajectory file '{output_traj_file}' created successfully.")
+    log.info(
+        "Trajectory file '%s' created successfully.",
+        output_traj_file,
+    )
 
 
 def create_nwchem_trajectory(
@@ -156,30 +205,38 @@ def create_nwchem_trajectory(
     mult=1,
     outer_loop_group_name: str = "outer_loop",
 ):
-    """
-    Creates an ASE trajectory file with NWChem energy and forces calculated for positions
-    taken from an HDF5 file.
+    """Create an ASE trajectory with NWChem energies and forces.
+
+    Positions are taken from an HDF5 file.
+
+    ```{versionadded} 0.0.3
+    ```
 
     Args:
-        template_atoms (ase.Atoms): The template ASE Atoms object (initial structure).
-        hdf5_file (str): Path to the HDF5 file containing positions.
-        output_traj_file (str): Path to the output trajectory file (e.g., 'nwchem_run.traj').
-        outer_loop_group_name (str, optional): Name of the group containing outer loop data. Defaults to "outer_loop".
+        template_atoms (ase.Atoms): The template ASE Atoms
+            object (initial structure).
+        hdf5_file (str): Path to the HDF5 file containing
+            positions.
+        output_traj_file (str): Path to the output trajectory
+            file (e.g., 'nwchem_run.traj').
+        outer_loop_group_name (str, optional): Name of the
+            group containing outer loop data.
+            Defaults to "outer_loop".
     """
 
     try:
         f = h5py.File(hdf5_file, "r")
     except FileNotFoundError:
-        print(f"Error: HDF5 file '{hdf5_file}' not found.")
+        log.error("HDF5 file '%s' not found.", hdf5_file)
         return
     except Exception as e:
-        print(f"An error occurred while opening HDF5 file: {e}")
+        log.error("Error opening HDF5 file: %s", e)
         return
 
     outer_loop_keys = [
         str(x) for x in np.sort([int(x) for x in f[outer_loop_group_name].keys()])
     ]
-    print(f"Available outer loop keys: {outer_loop_keys}")
+    log.info("Available outer loop keys: %s", outer_loop_keys)
 
     traj = Trajectory(output_traj_file, "w")
 
@@ -211,18 +268,25 @@ def create_nwchem_trajectory(
 
             # Assign calculator and calculate energy and forces
             atoms.calc = NWChem(**nwchem_kwargs)
-            print(f"Calculating for {key}")
+            log.info("Calculating for %s", key)
             atoms.get_potential_energy()
 
             # Write to trajectory
             traj.write(atoms)
 
         except KeyError as e:
-            print(f"Skipping key {key} due to missing data: {e}")
+            log.warning(
+                "Skipping key %s due to missing data: %s",
+                key,
+                e,
+            )
 
     f.close()
     traj.close()
-    print(f"NWChem trajectory file '{output_traj_file}' created successfully.")
+    log.info(
+        "NWChem trajectory file '%s' created successfully.",
+        output_traj_file,
+    )
 
 
 def create_full_traj_from_hdf5(
@@ -232,31 +296,41 @@ def create_full_traj_from_hdf5(
     outer_loop_group_name: str = "outer_loop",
     inner_loop_group_name: str = "initial_rotations",
 ):
-    """
-    Creates an ASE trajectory file from an HDF5 file containing optimization
-    data. Includes **estimated points** for the initial rotations and the
-    endpoints. These are correct (correspond to the actual counts) but is
-    slightly convoluted, since the HDF5 contains both the midpoint and the
-    "forward dimer". Instead, the length of the inner rotations keys is the
-    number of (0 energy) points added to the trajectory. This again makes
-    intuitive sense, since we have the Elvl cutoff in the GPRD as well.
+    """Create an ASE trajectory from an HDF5 optimization file.
+
+    Includes **estimated points** for the initial rotations
+    and the endpoints.
+
+    ```{versionadded} 0.0.3
+    ```
+
+    These are correct (correspond to the actual counts) but
+    is slightly convoluted, since the HDF5 contains both the
+    midpoint and the "forward dimer". Instead, the length of
+    the inner rotations keys is the number of (0 energy)
+    points added to the trajectory. This again makes
+    intuitive sense, since we have the Elvl cutoff in the
+    GPRD as well.
 
     Args:
         hdf5_file (str): Path to the HDF5 file.
-        output_traj_file (str): Path to the output trajectory file (e.g.,
-        'gprd_run.traj').
-        initial_structure_file (str): Path to the file containing the initial structure (e.g., 'pos.con').
-        outer_loop_group_name (str, optional): Name of the group containing
-        outer loop data. Defaults to "outer_loop".
+        output_traj_file (str): Path to the output trajectory
+            file (e.g., 'gprd_run.traj').
+        initial_structure_file (str): Path to the file
+            containing the initial structure
+            (e.g., 'pos.con').
+        outer_loop_group_name (str, optional): Name of the
+            group containing outer loop data.
+            Defaults to "outer_loop".
     """
 
     try:
         f = h5py.File(hdf5_file, "r")
     except FileNotFoundError:
-        print(f"Error: HDF5 file '{hdf5_file}' not found.")
+        log.error("HDF5 file '%s' not found.", hdf5_file)
         return
     except Exception as e:
-        print(f"An error occurred while opening HDF5 file: {e}")
+        log.error("Error opening HDF5 file: %s", e)
         return
 
     outer_loop_keys = [
@@ -267,17 +341,20 @@ def create_full_traj_from_hdf5(
         str(x) for x in np.sort([int(x) for x in f[inner_loop_group_name].keys()])
     ]
 
-    print(f"Available innner loop keys: {inner_loop_keys}")
-    print(f"Available outer loop keys: {outer_loop_keys}")
+    log.info("Available inner loop keys: %s", inner_loop_keys)
+    log.info("Available outer loop keys: %s", outer_loop_keys)
 
     try:
         init = aseio.read(initial_structure_file)
     except FileNotFoundError:
-        print(f"Error: Initial structure file '{initial_structure_file}' not found.")
+        log.error(
+            "Initial structure file '%s' not found.",
+            initial_structure_file,
+        )
         f.close()
         return
     except Exception as e:
-        print(f"An error occurred while reading initial structure file: {e}")
+        log.error("Error reading initial structure file: %s", e)
         f.close()
         return
 
@@ -320,10 +397,17 @@ def create_full_traj_from_hdf5(
                 traj.write(atoms)
 
         except KeyError as e:
-            print(f"Skipping key {key} due to missing data: {e}")
+            log.warning(
+                "Skipping key %s due to missing data: %s",
+                key,
+                e,
+            )
         except Exception as e:
-            print(f"An error occurred while processing key {key}: {e}")
+            log.error("Error processing key %s: %s", key, e)
 
     f.close()
     traj.close()
-    print(f"Trajectory file '{output_traj_file}' created successfully.")
+    log.info(
+        "Trajectory file '%s' created successfully.",
+        output_traj_file,
+    )

--- a/chemparseplot/parse/eon/minimization.py
+++ b/chemparseplot/parse/eon/minimization.py
@@ -7,6 +7,9 @@ from pathlib import Path
 def min_e_result(eresp: Path) -> dict:
     """Reads and parses the results.dat file.
 
+    ```{versionadded} 0.0.3
+    ```
+
     Args:
         eresp: Path to the eOn results directory.
 

--- a/chemparseplot/parse/eon/neb.py
+++ b/chemparseplot/parse/eon/neb.py
@@ -38,6 +38,7 @@ def _validate_data_atoms_match(z_data, atoms, dat_file_name):
 
 def load_or_compute_data(
     cache_file: Path | None,
+    *,
     force_recompute: bool,
     validation_check: Callable[[pl.DataFrame], None],
     computation_callback: Callable[[], pl.DataFrame],
@@ -77,7 +78,7 @@ def load_structures_and_calculate_additional_rmsd(
     ira_kmax: float,
     sp_file: Path | None = None,
 ):
-    """Loads the main trajectory and calculates RMSD for any additional comparison structures.
+    """Loads the main trajectory and calculates RMSD for additional comparison structures.
 
     ```{versionadded} 0.1.0
     ```
@@ -181,6 +182,7 @@ def aggregate_neb_landscape_data(
     all_con_paths: list[Path],
     y_data_column: int,
     ira_instance,  # Can be None
+    *,
     cache_file: Path | None = None,
     force_recompute: bool = False,
     ira_kmax: float = 1.8,
@@ -202,9 +204,11 @@ def aggregate_neb_landscape_data(
 
     def validate_landscape_cache(df: pl.DataFrame):
         if "p" not in df.columns:
-            raise ValueError("Cache missing 'p' column.")
+            msg = "Cache missing 'p' column."
+            raise ValueError(msg)
         if "grad_r" not in df.columns:
-            raise ValueError("Cache missing gradient columns (outdated).")
+            msg = "Cache missing gradient columns (outdated)."
+            raise ValueError(msg)
 
     def compute_landscape_data() -> pl.DataFrame:
         all_dfs = []
@@ -278,7 +282,7 @@ def load_augmenting_neb_data(
     ```{versionadded} 0.1.0
     ```
     """
-    from chemparseplot.parse.file_ import find_file_paths
+    from chemparseplot.parse.file_ import find_file_paths  # noqa: PLC0415
 
     dat_paths = find_file_paths(dat_pattern)
     con_paths = find_file_paths(con_pattern)
@@ -297,7 +301,7 @@ def load_augmenting_neb_data(
     all_dfs = []
     ira_instance = ira_mod.IRA() if ira_mod else None
 
-    for i, (d, c) in enumerate(zip(dat_paths, con_paths)):
+    for _, (d, c) in enumerate(zip(dat_paths, con_paths, strict=False)):
         try:
             # Step -1 indicates 'background/augmented' data
             df = _process_single_path_step(
@@ -319,6 +323,7 @@ def load_augmenting_neb_data(
 
 def compute_profile_rmsd(
     atoms_list: list[Atoms],
+    *,
     cache_file: Path | None,
     force_recompute: bool,
     ira_kmax: float,
@@ -331,11 +336,11 @@ def compute_profile_rmsd(
 
     def validate_profile_cache(df: pl.DataFrame):
         if "p" in df.columns:
-            raise ValueError("Cache contains 'p' column (looks like landscape data).")
+            msg = "Cache contains 'p' column (looks like landscape data)."
+            raise ValueError(msg)
         if df.height != len(atoms_list):
-            raise ValueError(
-                f"Size mismatch: {df.height} vs {len(atoms_list)} structures."
-            )
+            msg = f"Size mismatch: {df.height} vs {len(atoms_list)} structures."
+            raise ValueError(msg)
 
     def compute_data() -> pl.DataFrame:
         ira_instance = ira_mod.IRA() if ira_mod else None

--- a/chemparseplot/parse/eon/neb.py
+++ b/chemparseplot/parse/eon/neb.py
@@ -43,7 +43,11 @@ def load_or_compute_data(
     computation_callback: Callable[[], pl.DataFrame],
     context_name: str,
 ) -> pl.DataFrame:
-    """Retrieves data from a parquet cache or triggers a computation callback."""
+    """Retrieves data from a parquet cache or triggers a computation callback.
+
+    ```{versionadded} 0.1.0
+    ```
+    """
     if cache_file and cache_file.exists() and not force_recompute:
         log.info(f"Loading cached {context_name} data from {cache_file}...")
         try:
@@ -73,7 +77,11 @@ def load_structures_and_calculate_additional_rmsd(
     ira_kmax: float,
     sp_file: Path | None = None,
 ):
-    """Loads the main trajectory and calculates RMSD for any additional comparison structures."""
+    """Loads the main trajectory and calculates RMSD for any additional comparison structures.
+
+    ```{versionadded} 0.1.0
+    ```
+    """
     log.info(f"Reading structures from {con_file}")
     atoms_list = ase_read(con_file, index=":")
     log.info(f"Loaded {len(atoms_list)} structures.")
@@ -155,11 +163,17 @@ def _process_single_path_step(
     ref = ref_atoms if ref_atoms is not None else atoms_list_step[0]
     prod = prod_atoms if prod_atoms is not None else atoms_list_step[-1]
 
-    rmsd_r = calculate_rmsd_from_ref(atoms_list_step, ira_instance, ref_atom=ref, ira_kmax=ira_kmax)
-    rmsd_p = calculate_rmsd_from_ref(atoms_list_step, ira_instance, ref_atom=prod, ira_kmax=ira_kmax)
+    rmsd_r = calculate_rmsd_from_ref(
+        atoms_list_step, ira_instance, ref_atom=ref, ira_kmax=ira_kmax
+    )
+    rmsd_p = calculate_rmsd_from_ref(
+        atoms_list_step, ira_instance, ref_atom=prod, ira_kmax=ira_kmax
+    )
 
     grad_r, grad_p = compute_synthetic_gradients(rmsd_r, rmsd_p, f_para_step)
-    return create_landscape_dataframe(rmsd_r, rmsd_p, grad_r, grad_p, z_data_step, int(step_idx))
+    return create_landscape_dataframe(
+        rmsd_r, rmsd_p, grad_r, grad_p, z_data_step, int(step_idx)
+    )
 
 
 def aggregate_neb_landscape_data(
@@ -176,7 +190,11 @@ def aggregate_neb_landscape_data(
     ref_atoms: Atoms | None = None,
     prod_atoms: Atoms | None = None,
 ) -> pl.DataFrame:
-    """Aggregates data from multiple NEB steps for landscape visualization."""
+    """Aggregates data from multiple NEB steps for landscape visualization.
+
+    ```{versionadded} 0.1.0
+    ```
+    """
 
     # Init IRA if not passed
     if ira_instance is None and ira_mod is not None:
@@ -202,7 +220,7 @@ def aggregate_neb_landscape_data(
                 ira_kmax=ira_kmax,
             )
             if not df_aug.is_empty():
-                 all_dfs.append(df_aug)
+                all_dfs.append(df_aug)
 
         # Synchronization check
         paths_dat = all_dat_paths
@@ -256,6 +274,9 @@ def load_augmenting_neb_data(
     """
     Loads external NEB paths (dat+con) to augment the landscape fit.
     Forces projection onto the MAIN path's R/P coordinates.
+
+    ```{versionadded} 0.1.0
+    ```
     """
     from chemparseplot.parse.file_ import find_file_paths
 
@@ -302,7 +323,11 @@ def compute_profile_rmsd(
     force_recompute: bool,
     ira_kmax: float,
 ) -> pl.DataFrame:
-    """Computes RMSD for a 1D profile."""
+    """Computes RMSD for a 1D profile.
+
+    ```{versionadded} 0.1.0
+    ```
+    """
 
     def validate_profile_cache(df: pl.DataFrame):
         if "p" in df.columns:
@@ -331,6 +356,9 @@ def compute_profile_rmsd(
 def estimate_rbf_smoothing(df: pl.DataFrame) -> float:
     """
     Estimates a smoothing parameter for RBF interpolation.
+
+    ```{versionadded} 0.1.0
+    ```
 
     Calculates the median Euclidean distance between sequential points in the path
     and uses that value as the smoothing factor.

--- a/chemparseplot/parse/eon/saddle_search.py
+++ b/chemparseplot/parse/eon/saddle_search.py
@@ -2,18 +2,23 @@ import configparser
 import gzip
 import os
 import re
-from pathlib import Path
 from enum import Enum
+from pathlib import Path
 
 import numpy as np
+from rgpycrumbs.basetypes import DimerOpt, MolGeom, SaddleMeasure, SpinID
 from rgpycrumbs.parsers.bless import BLESS_LOG
 from rgpycrumbs.parsers.common import _NUM
 from rgpycrumbs.search.helpers import tail
 
-from rgpycrumbs.basetypes import DimerOpt, MolGeom, SaddleMeasure, SpinID
-
 
 class EONSaddleStatus(Enum):
+    """Status codes returned by eOn saddle point searches.
+
+    ```{versionadded} 0.0.3
+    ```
+    """
+
     # See SaddleSearchJob.cpp for the ordering
     # (numerical_status, descriptive_string)
     GOOD = 0, "Success"
@@ -56,10 +61,15 @@ class EONSaddleStatus(Enum):
 
 
 def extract_saddle_gprd(log: list[str]):
+    """Extract saddle point geometry from GPRD log lines.
+
+    ```{versionadded} 0.0.3
+    ```
+    """
     logdata = [BLESS_LOG.search(x).group("logdata").strip() for x in log]
     numdat = []
     for line in logdata:
-        if line.isdigit() or line.startswith("-") and line[1:].isdigit():
+        if line.isdigit() or (line.startswith("-") and line[1:].isdigit()):
             numdat.append(float(line))
         if _NUM.match(line):
             numdat.append(np.array(_NUM.findall(line), dtype=float))
@@ -247,6 +257,9 @@ def _get_methods(eresp: Path) -> DimerOpt:
 def parse_eon_saddle(eresp: Path, rloc: "SpinID") -> "SaddleMeasure":
     """Parses eOn saddle point search results from a directory.
 
+    ```{versionadded} 0.0.3
+    ```
+
     Args:
         eresp: Path to the directory containing eOn results.
         rloc: A SpinID object.
@@ -268,7 +281,7 @@ def parse_eon_saddle(eresp: Path, rloc: "SpinID") -> "SaddleMeasure":
             dimer_trans=meth.trans,
         )
 
-    if list(results_data.keys()) == ['termination_status']:
+    if list(results_data.keys()) == ["termination_status"]:
         return SaddleMeasure(
             mol_id=getattr(rloc, "mol_id", None),
             spin=getattr(rloc, "spin", None),

--- a/chemparseplot/parse/eon/saddle_search.py
+++ b/chemparseplot/parse/eon/saddle_search.py
@@ -1,5 +1,6 @@
 import configparser
 import gzip
+import logging
 import os
 import re
 from enum import Enum
@@ -10,6 +11,8 @@ from rgpycrumbs.basetypes import DimerOpt, MolGeom, SaddleMeasure, SpinID
 from rgpycrumbs.parsers.bless import BLESS_LOG
 from rgpycrumbs.parsers.common import _NUM
 from rgpycrumbs.search.helpers import tail
+
+log = logging.getLogger(__name__)
 
 
 class EONSaddleStatus(Enum):
@@ -123,7 +126,7 @@ def _find_log_file(eresp: Path) -> Path | None:
     """
     log_files = list(eresp.glob("*.log.gz"))
     if not log_files:
-        print(f"Warning: *.log.gz not found for {eresp}")
+        log.warning("*.log.gz not found for %s", eresp)
         return None
 
     # Sort log files by modification time (most recent first)
@@ -137,7 +140,7 @@ def _find_log_file(eresp: Path) -> Path | None:
         if not fcheck:  # If "Fail" is NOT in any of the last 5 lines
             return f
 
-    print(f"No valid log files found in {eresp}")
+    log.warning("No valid log files found in %s", eresp)
     return None
 
 

--- a/chemparseplot/parse/file_.py
+++ b/chemparseplot/parse/file_.py
@@ -1,11 +1,16 @@
-import logging
 import glob
+import logging
 from pathlib import Path
 
 log = logging.getLogger(__name__)
 
+
 def find_file_paths(file_pattern: str) -> list[Path]:
-    """Finds and sorts files matching a glob pattern."""
+    """Finds and sorts files matching a glob pattern.
+
+    ```{versionadded} 0.1.0
+    ```
+    """
     log.info(f"Searching for files with pattern: '{file_pattern}'")
     file_paths = sorted(Path(p) for p in glob.glob(file_pattern))
     log.info(f"Found {len(file_paths)} file(s).")

--- a/chemparseplot/parse/neb_utils.py
+++ b/chemparseplot/parse/neb_utils.py
@@ -32,19 +32,25 @@ def calculate_landscape_coords(
     :param ira_kmax: kmax factor for IRA.
     :return: A tuple of (rmsd_r, rmsd_p) arrays.
     """
-    from concurrent.futures import ThreadPoolExecutor
+    from concurrent.futures import ThreadPoolExecutor  # noqa: PLC0415
 
-    from rgpycrumbs.geom.api.alignment import calculate_rmsd_from_ref
+    from rgpycrumbs.geom.api.alignment import calculate_rmsd_from_ref  # noqa: PLC0415
 
     log.info("Calculating landscape coordinates (RMSD-R, RMSD-P)...")
     with ThreadPoolExecutor(max_workers=2) as pool:
         fut_r = pool.submit(
             calculate_rmsd_from_ref,
-            atoms_list, ira_instance, ref_atom=atoms_list[0], ira_kmax=ira_kmax,
+            atoms_list,
+            ira_instance,
+            ref_atom=atoms_list[0],
+            ira_kmax=ira_kmax,
         )
         fut_p = pool.submit(
             calculate_rmsd_from_ref,
-            atoms_list, ira_instance, ref_atom=atoms_list[-1], ira_kmax=ira_kmax,
+            atoms_list,
+            ira_instance,
+            ref_atom=atoms_list[-1],
+            ira_kmax=ira_kmax,
         )
         rmsd_r = fut_r.result()
         rmsd_p = fut_p.result()

--- a/chemparseplot/parse/neb_utils.py
+++ b/chemparseplot/parse/neb_utils.py
@@ -1,5 +1,8 @@
 """Shared NEB analysis utilities.
 
+```{versionadded} 1.2.0
+```
+
 Functions common to all NEB trajectory sources (eOn, extxyz, etc.):
 RMSD landscape coordinate calculation, synthetic 2D gradient projection,
 and landscape DataFrame construction.
@@ -18,6 +21,9 @@ def calculate_landscape_coords(
     atoms_list: list[Atoms], ira_instance, ira_kmax: float
 ) -> tuple[np.ndarray, np.ndarray]:
     """Calculate 2D landscape coordinates (RMSD-R, RMSD-P) for a path.
+
+    ```{versionadded} 1.2.0
+    ```
 
     Uses the first frame as reactant reference and the last as product.
 
@@ -42,6 +48,9 @@ def compute_synthetic_gradients(
     rmsd_r: np.ndarray, rmsd_p: np.ndarray, f_para: np.ndarray
 ) -> tuple[np.ndarray, np.ndarray]:
     """Project parallel force onto the 2D RMSD coordinate system.
+
+    ```{versionadded} 1.2.0
+    ```
 
     Computes synthetic gradients by projecting the NEB parallel force
     component along the tangent direction in (RMSD-R, RMSD-P) space.
@@ -71,6 +80,9 @@ def create_landscape_dataframe(
     step: int,
 ) -> pl.DataFrame:
     """Build a landscape DataFrame with the standard schema.
+
+    ```{versionadded} 1.2.0
+    ```
 
     :param rmsd_r: RMSD from reactant.
     :param rmsd_p: RMSD from product.

--- a/chemparseplot/parse/neb_utils.py
+++ b/chemparseplot/parse/neb_utils.py
@@ -32,15 +32,22 @@ def calculate_landscape_coords(
     :param ira_kmax: kmax factor for IRA.
     :return: A tuple of (rmsd_r, rmsd_p) arrays.
     """
+    from concurrent.futures import ThreadPoolExecutor
+
     from rgpycrumbs.geom.api.alignment import calculate_rmsd_from_ref
 
     log.info("Calculating landscape coordinates (RMSD-R, RMSD-P)...")
-    rmsd_r = calculate_rmsd_from_ref(
-        atoms_list, ira_instance, ref_atom=atoms_list[0], ira_kmax=ira_kmax
-    )
-    rmsd_p = calculate_rmsd_from_ref(
-        atoms_list, ira_instance, ref_atom=atoms_list[-1], ira_kmax=ira_kmax
-    )
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        fut_r = pool.submit(
+            calculate_rmsd_from_ref,
+            atoms_list, ira_instance, ref_atom=atoms_list[0], ira_kmax=ira_kmax,
+        )
+        fut_p = pool.submit(
+            calculate_rmsd_from_ref,
+            atoms_list, ira_instance, ref_atom=atoms_list[-1], ira_kmax=ira_kmax,
+        )
+        rmsd_r = fut_r.result()
+        rmsd_p = fut_p.result()
     return rmsd_r, rmsd_p
 
 

--- a/chemparseplot/parse/neb_utils.py
+++ b/chemparseplot/parse/neb_utils.py
@@ -1,0 +1,92 @@
+"""Shared NEB analysis utilities.
+
+Functions common to all NEB trajectory sources (eOn, extxyz, etc.):
+RMSD landscape coordinate calculation, synthetic 2D gradient projection,
+and landscape DataFrame construction.
+"""
+
+import logging
+
+import numpy as np
+import polars as pl
+from ase import Atoms
+
+log = logging.getLogger(__name__)
+
+
+def calculate_landscape_coords(
+    atoms_list: list[Atoms], ira_instance, ira_kmax: float
+) -> tuple[np.ndarray, np.ndarray]:
+    """Calculate 2D landscape coordinates (RMSD-R, RMSD-P) for a path.
+
+    Uses the first frame as reactant reference and the last as product.
+
+    :param atoms_list: List of ASE Atoms objects representing the path.
+    :param ira_instance: An instantiated IRA object (or None).
+    :param ira_kmax: kmax factor for IRA.
+    :return: A tuple of (rmsd_r, rmsd_p) arrays.
+    """
+    from rgpycrumbs.geom.api.alignment import calculate_rmsd_from_ref
+
+    log.info("Calculating landscape coordinates (RMSD-R, RMSD-P)...")
+    rmsd_r = calculate_rmsd_from_ref(
+        atoms_list, ira_instance, ref_atom=atoms_list[0], ira_kmax=ira_kmax
+    )
+    rmsd_p = calculate_rmsd_from_ref(
+        atoms_list, ira_instance, ref_atom=atoms_list[-1], ira_kmax=ira_kmax
+    )
+    return rmsd_r, rmsd_p
+
+
+def compute_synthetic_gradients(
+    rmsd_r: np.ndarray, rmsd_p: np.ndarray, f_para: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Project parallel force onto the 2D RMSD coordinate system.
+
+    Computes synthetic gradients by projecting the NEB parallel force
+    component along the tangent direction in (RMSD-R, RMSD-P) space.
+
+    :param rmsd_r: RMSD from reactant for each image.
+    :param rmsd_p: RMSD from product for each image.
+    :param f_para: Force component parallel to the path for each image.
+    :return: (grad_r, grad_p) arrays.
+    """
+    dr = np.gradient(rmsd_r)
+    dp = np.gradient(rmsd_p)
+    norm_ds = np.sqrt(dr**2 + dp**2)
+    norm_ds[norm_ds == 0] = 1.0
+    tr = dr / norm_ds
+    tp = dp / norm_ds
+    grad_r = -f_para * tr
+    grad_p = -f_para * tp
+    return grad_r, grad_p
+
+
+def create_landscape_dataframe(
+    rmsd_r: np.ndarray,
+    rmsd_p: np.ndarray,
+    grad_r: np.ndarray,
+    grad_p: np.ndarray,
+    z: np.ndarray,
+    step: int,
+) -> pl.DataFrame:
+    """Build a landscape DataFrame with the standard schema.
+
+    :param rmsd_r: RMSD from reactant.
+    :param rmsd_p: RMSD from product.
+    :param grad_r: Synthetic gradient in R direction.
+    :param grad_p: Synthetic gradient in P direction.
+    :param z: Energy (or eigenvalue) data.
+    :param step: Step index for this path segment.
+    :return: Polars DataFrame with columns [r, p, grad_r, grad_p, z, step].
+    """
+    return pl.DataFrame(
+        {
+            "r": rmsd_r,
+            "p": rmsd_p,
+            "grad_r": grad_r,
+            "grad_p": grad_p,
+            "z": z,
+            "step": step,
+        }
+    )

--- a/chemparseplot/parse/orca/geomscan.py
+++ b/chemparseplot/parse/orca/geomscan.py
@@ -10,6 +10,7 @@ For parsing outputs from input files like this:
 end
 *xyzfile 0 1 h2_base.xyz
 """
+
 import re
 
 import chemparseplot.parse.converter as conv
@@ -20,6 +21,9 @@ from chemparseplot.units import Q_
 def extract_energy_data(data: str, energy_type: str) -> tuple[Q_, Q_]:
     """
     Extracts and converts the energy data for a specified energy type.
+
+    ```{versionadded} 0.0.2
+    ```
 
     This function assumes the input data is a blob of text. It searches for
     'Calculated Surface' followed by the specified energy type ('Actual' or 'SCF')

--- a/chemparseplot/parse/orca/neb/interp.py
+++ b/chemparseplot/parse/orca/neb/interp.py
@@ -1,7 +1,11 @@
 # SPDX-FileCopyrightText: 2023-present Rohit Goswami <rog32@hi.is>
 #
 # SPDX-License-Identifier: MIT
-"""
+"""For parsing .interp files from ORCA NEB calculations.
+
+```{versionadded} 0.0.2
+```
+
 For parsing .interp files from inputs like:
 !B3LYP def2-SVP NEB-CI
 %neb
@@ -10,11 +14,13 @@ Product "prod.xyz"
 end
 *xyzfile 0 1 react.xyz
 """
+
 import re
+
+from rgpycrumbs.basetypes import nebiter, nebpath
 
 import chemparseplot.parse.converter as conv
 import chemparseplot.parse.patterns as pat
-from rgpycrumbs.basetypes import nebiter, nebpath
 from chemparseplot.units import Q_
 
 # fmt: off
@@ -27,6 +33,11 @@ INTERP_PAT = (
 
 
 def extract_interp_points(text: str) -> list[int, Q_, Q_]:
+    """Extract NEB interpolation points from an ORCA .interp file.
+
+    ```{versionadded} 0.0.2
+    ```
+    """
     data = []
     for match in re.finditer(INTERP_PAT, text, re.DOTALL):
         iteration = int(match.group("iteration"))

--- a/chemparseplot/parse/patterns.py
+++ b/chemparseplot/parse/patterns.py
@@ -1,6 +1,11 @@
 # SPDX-FileCopyrightText: 2023-present Rohit Goswami <rog32@hi.is>
 #
 # SPDX-License-Identifier: MIT
+"""Regex patterns for parsing multi-column numeric data.
+
+```{versionadded} 0.0.2
+```
+"""
 
 # https://regex101.com/r/jHAG2T/1
 # DIGIT pattern for a floating-point number, possibly negative
@@ -8,6 +13,11 @@ DIGIT = r"-?\d+\.\d+"
 
 
 def create_multicol_pattern(num_cols, pname="multicolnum"):
+    """Build a regex pattern that matches *num_cols* whitespace-separated floats.
+
+    ```{versionadded} 0.0.2
+    ```
+    """
     if num_cols < 1:
         error_message = "Number of columns must be at least 1"
         raise ValueError(error_message)

--- a/chemparseplot/parse/sella/saddle_search.py
+++ b/chemparseplot/parse/sella/saddle_search.py
@@ -1,22 +1,24 @@
-from dataclasses import dataclass
-from pathlib import Path
-from collections import Counter
-
-from ase.io import read
-from rgpycrumbs.time.helpers import one_day_tdelta
-
-from rgpycrumbs.basetypes import SaddleMeasure, SpinID
-import ase
-
 import datetime
 import time
-from collections import namedtuple
+from collections import Counter, namedtuple
+from dataclasses import dataclass
+from pathlib import Path
+
+import ase
 import numpy as np
+from ase.io import read
+from rgpycrumbs.basetypes import SaddleMeasure, SpinID
+from rgpycrumbs.time.helpers import one_day_tdelta
 
 SellaLog = namedtuple(
     "SellaLog",
     ["step_id", "time_float", "energy", "fmax", "cmax", "rtrust", "rho", "trj_id"],
 )
+"""Named tuple for a single Sella log entry.
+
+```{versionadded} 0.0.3
+```
+"""
 
 
 def _sella_loglist(log_f):
@@ -42,12 +44,24 @@ def _sella_loglist(log_f):
 
 @dataclass
 class LogStart:
+    """Start-of-log record for a Sella calculation.
+
+    ```{versionadded} 0.0.3
+    ```
+    """
+
     tstart: str
     init_energy: float
 
 
 @dataclass
 class LogEnd:
+    """End-of-log record for a Sella calculation.
+
+    ```{versionadded} 0.0.3
+    ```
+    """
+
     iter_steps: int
     tend: str
     saddle_energy: float
@@ -88,6 +102,9 @@ class LogEnd:
 def parse_log_line(line: str, line_type: str) -> LogStart | LogEnd | None:
     """Parses a log line based on its type.
 
+    ```{versionadded} 0.0.3
+    ```
+
     Args:
         line: The log line string.
         line_type: Either "start" or "end" indicating the line type.
@@ -116,6 +133,9 @@ def parse_log_line(line: str, line_type: str) -> LogStart | LogEnd | None:
 def parse_sella_saddle(eresp: Path, rloc: SpinID) -> SaddleMeasure:
     """Parses Sella saddle point calculation results.
 
+    ```{versionadded} 0.0.3
+    ```
+
     Args:
         eresp: Path to the directory containing the results.
         rloc: SpinID object containing molecule ID and spin.
@@ -132,9 +152,7 @@ def parse_sella_saddle(eresp: Path, rloc: SpinID) -> SaddleMeasure:
             traj = read(traj_file, index=":")
             npes = len(traj)
         except Exception as e:
-            print(
-                f"Warning: Could not read or process trajectory file {traj_file}: {e}"
-            )
+            print(f"Warning: Could not read or process trajectory file {traj_file}: {e}")
             return SaddleMeasure()
     else:
         print(f"Warning: No .traj file found in {eresp}. Using npes.txt or default.")
@@ -197,6 +215,11 @@ def _get_ghosts(traj_f):
 
 
 def get_unique_frames(traj, sloglist: list, nround: int = 2):
+    """Filter trajectory to unique frames by matching rounded fmax values.
+
+    ```{versionadded} 0.0.3
+    ```
+    """
     # XXX: This is fairly idiotic, but it turns out empirically filtering by
     # rounding the fmax to 2 seems to give the same number as the number of
     # steps, so those frames are the "unique" ones.
@@ -225,6 +248,11 @@ def get_unique_frames(traj, sloglist: list, nround: int = 2):
 
 
 def make_geom_traj(traj_f, log_f, out_f="geom_step.traj"):
+    """Write a geometry-step trajectory from a Sella trajectory and log file.
+
+    ```{versionadded} 0.0.3
+    ```
+    """
     # XXX: This uses a logfile which has the patch for writing the trajectory ID
     traj = ase.io.read(traj_f, ":")
     sellalog = _sella_loglist(log_f)

--- a/chemparseplot/parse/trajectory/__init__.py
+++ b/chemparseplot/parse/trajectory/__init__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-from chemparseplot.parse.trajectory import neb
+from chemparseplot.parse.trajectory import hdf5, neb

--- a/chemparseplot/parse/trajectory/__init__.py
+++ b/chemparseplot/parse/trajectory/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2023-present Rohit Goswami <rog32@hi.is>
+#
+# SPDX-License-Identifier: MIT
+
+from chemparseplot.parse.trajectory import neb

--- a/chemparseplot/parse/trajectory/hdf5.py
+++ b/chemparseplot/parse/trajectory/hdf5.py
@@ -250,10 +250,10 @@ def history_to_landscape_df(h5_file: str, ira_kmax: float = 1.8):
     :return: Polars DataFrame with columns
         ``[r, p, grad_r, grad_p, z, step]``.
     """
-    import polars as pl
+    import polars as pl  # noqa: PLC0415
 
     try:
-        from rgpycrumbs._aux import _import_from_parent_env
+        from rgpycrumbs._aux import _import_from_parent_env  # noqa: PLC0415
 
         ira_mod = _import_from_parent_env("ira_mod")
         ira_instance = ira_mod.IRA()

--- a/chemparseplot/parse/trajectory/hdf5.py
+++ b/chemparseplot/parse/trajectory/hdf5.py
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: 2023-present Rohit Goswami <rog32@hi.is>
+#
+# SPDX-License-Identifier: MIT
+"""HDF5 NEB reader for ChemGP output.
+
+Reads ``neb_result.h5`` (final converged path) and ``neb_history.h5``
+(per-step optimization history) produced by ChemGP's Julia NEB optimizer.
+
+These files contain pre-computed ``f_para`` and ``rxn_coord``, so profile
+data can be read directly without recomputing the Henkelman-Jonsson tangent.
+"""
+
+import logging
+
+import h5py
+import numpy as np
+from ase import Atoms
+from ase.calculators.singlepoint import SinglePointCalculator
+
+from chemparseplot.parse.neb_utils import (
+    calculate_landscape_coords,
+    compute_synthetic_gradients,
+    create_landscape_dataframe,
+)
+
+log = logging.getLogger(__name__)
+
+
+def _read_path_group(grp: h5py.Group) -> dict:
+    """Extract arrays from an HDF5 path group.
+
+    :param grp: An h5py Group containing ``images``, ``energies``,
+        ``gradients``, ``f_para``, and ``rxn_coord`` datasets.
+    :return: Dictionary with numpy arrays for each field.
+    """
+    return {
+        "images": np.asarray(grp["images"]),
+        "energies": np.asarray(grp["energies"]),
+        "gradients": np.asarray(grp["gradients"]),
+        "f_para": np.asarray(grp["f_para"]),
+        "rxn_coord": np.asarray(grp["rxn_coord"]),
+    }
+
+
+def _reconstruct_atoms(
+    images: np.ndarray,
+    atomic_numbers: np.ndarray | None,
+    cell: np.ndarray | None,
+    gradients: np.ndarray,
+    energies: np.ndarray,
+) -> list[Atoms]:
+    """Rebuild ASE Atoms from flattened positions and metadata.
+
+    Each image's positions are ``(ndof,)`` where ``ndof = 3 * n_atoms``.
+    A SinglePointCalculator is attached with energy and forces (``-gradients``).
+
+    :param images: Array of shape ``(n_images, ndof)``.
+    :param atomic_numbers: Optional array of shape ``(n_atoms,)``.
+    :param cell: Optional array of shape ``(9,)`` (flattened 3x3 cell).
+    :param gradients: Array of shape ``(n_images, ndof)``.
+    :param energies: Array of shape ``(n_images,)``.
+    :return: List of ASE Atoms objects with calculators attached.
+    """
+    n_images = images.shape[0]
+    ndof = images.shape[1]
+    n_atoms = ndof // 3
+
+    if atomic_numbers is None:
+        atomic_numbers = np.ones(n_atoms, dtype=int)  # default to H
+
+    cell_matrix = None
+    pbc = False
+    if cell is not None:
+        cell_matrix = cell.reshape(3, 3)
+        pbc = True
+
+    atoms_list = []
+    for i in range(n_images):
+        positions = images[i].reshape(n_atoms, 3)
+        forces = -gradients[i].reshape(n_atoms, 3)
+        energy = float(energies[i])
+
+        atoms = Atoms(
+            numbers=atomic_numbers,
+            positions=positions,
+            cell=cell_matrix,
+            pbc=pbc,
+        )
+        calc = SinglePointCalculator(
+            atoms, energy=energy, forces=forces
+        )
+        atoms.calc = calc
+        atoms_list.append(atoms)
+
+    return atoms_list
+
+
+def load_neb_result(h5_file: str) -> dict:
+    """Read a ChemGP ``neb_result.h5`` file.
+
+    :param h5_file: Path to the HDF5 result file.
+    :return: Dictionary with keys ``path`` (from :func:`_read_path_group`),
+        ``convergence`` (dict of arrays), and ``metadata`` (dict of scalars
+        and optional arrays).
+    """
+    with h5py.File(h5_file, "r") as f:
+        path_data = _read_path_group(f["path"])
+
+        convergence = {}
+        if "convergence" in f:
+            conv_grp = f["convergence"]
+            for key in conv_grp:
+                convergence[key] = np.asarray(conv_grp[key])
+
+        metadata = {}
+        if "metadata" in f:
+            meta_grp = f["metadata"]
+            for key in meta_grp:
+                val = meta_grp[key]
+                if val.shape == ():
+                    metadata[key] = val[()]
+                else:
+                    metadata[key] = np.asarray(val)
+
+    log.info(
+        "Loaded NEB result: %d images from %s",
+        path_data["images"].shape[0],
+        h5_file,
+    )
+    return {
+        "path": path_data,
+        "convergence": convergence,
+        "metadata": metadata,
+    }
+
+
+def load_neb_history(h5_file: str) -> list[dict]:
+    """Read a ChemGP ``neb_history.h5`` file.
+
+    :param h5_file: Path to the HDF5 history file.
+    :return: List of dicts (one per optimization step), sorted by step
+        number. Each dict has the same structure as :func:`_read_path_group`.
+    """
+    steps = []
+    with h5py.File(h5_file, "r") as f:
+        steps_grp = f["steps"]
+        step_keys = sorted(steps_grp.keys(), key=int)
+        for key in step_keys:
+            steps.append(_read_path_group(steps_grp[key]))
+
+    log.info(
+        "Loaded NEB history: %d steps from %s", len(steps), h5_file
+    )
+    return steps
+
+
+def result_to_profile_dat(h5_file: str) -> np.ndarray:
+    """Convert a result HDF5 to a (5, N) profile array.
+
+    Layout matches eOn ``.dat`` format:
+    ``[index, rxn_coord, energy, f_para, zeros]``.
+
+    Reads directly from pre-computed HDF5 fields -- no tangent recomputation.
+
+    :param h5_file: Path to ``neb_result.h5``.
+    :return: Array of shape ``(5, n_images)``.
+    """
+    result = load_neb_result(h5_file)
+    path = result["path"]
+    n = len(path["energies"])
+    return np.array([
+        np.arange(n, dtype=float),
+        path["rxn_coord"],
+        path["energies"],
+        path["f_para"],
+        np.zeros(n),
+    ])
+
+
+def result_to_atoms_list(h5_file: str) -> list[Atoms]:
+    """Reconstruct ASE Atoms from a result HDF5 file.
+
+    :param h5_file: Path to ``neb_result.h5``.
+    :return: List of Atoms with SinglePointCalculators attached.
+    """
+    result = load_neb_result(h5_file)
+    path = result["path"]
+    meta = result["metadata"]
+    return _reconstruct_atoms(
+        path["images"],
+        meta.get("atomic_numbers"),
+        meta.get("cell"),
+        path["gradients"],
+        path["energies"],
+    )
+
+
+def history_to_profile_dats(h5_file: str) -> list[np.ndarray]:
+    """Convert a history HDF5 to a list of (5, N) profile arrays.
+
+    One array per optimization step, sorted by step number.
+
+    :param h5_file: Path to ``neb_history.h5``.
+    :return: List of arrays, each of shape ``(5, n_images)``.
+    """
+    steps = load_neb_history(h5_file)
+    dats = []
+    for step_data in steps:
+        n = len(step_data["energies"])
+        dat = np.array([
+            np.arange(n, dtype=float),
+            step_data["rxn_coord"],
+            step_data["energies"],
+            step_data["f_para"],
+            np.zeros(n),
+        ])
+        dats.append(dat)
+    return dats
+
+
+def history_to_landscape_df(
+    h5_file: str, ira_kmax: float = 1.8
+):
+    """Convert a history HDF5 to a landscape DataFrame.
+
+    Reconstructs Atoms per step for RMSD coordinates, uses pre-computed
+    ``f_para`` for synthetic gradients.
+
+    :param h5_file: Path to ``neb_history.h5``.
+    :param ira_kmax: kmax factor for IRA alignment.
+    :return: Polars DataFrame with columns
+        ``[r, p, grad_r, grad_p, z, step]``.
+    """
+    import polars as pl
+
+    try:
+        from rgpycrumbs._aux import _import_from_parent_env
+
+        ira_mod = _import_from_parent_env("ira_mod")
+        ira_instance = ira_mod.IRA()
+    except (ImportError, AttributeError):
+        ira_instance = None
+
+    with h5py.File(h5_file, "r") as f:
+        meta = f.get("metadata", {})
+        atomic_numbers = (
+            np.asarray(meta["atomic_numbers"])
+            if "atomic_numbers" in meta
+            else None
+        )
+        cell = (
+            np.asarray(meta["cell"]) if "cell" in meta else None
+        )
+
+    steps = load_neb_history(h5_file)
+    frames = []
+
+    for step_idx, step_data in enumerate(steps):
+        atoms_list = _reconstruct_atoms(
+            step_data["images"],
+            atomic_numbers,
+            cell,
+            step_data["gradients"],
+            step_data["energies"],
+        )
+
+        rmsd_r, rmsd_p = calculate_landscape_coords(
+            atoms_list, ira_instance, ira_kmax
+        )
+        grad_r, grad_p = compute_synthetic_gradients(
+            rmsd_r, rmsd_p, step_data["f_para"]
+        )
+        df = create_landscape_dataframe(
+            rmsd_r,
+            rmsd_p,
+            grad_r,
+            grad_p,
+            step_data["energies"],
+            step_idx,
+        )
+        frames.append(df)
+
+    return pl.concat(frames)

--- a/chemparseplot/parse/trajectory/neb.py
+++ b/chemparseplot/parse/trajectory/neb.py
@@ -29,7 +29,7 @@ def _get_energy(atoms: Atoms) -> float:
         try:
             return atoms.get_potential_energy()
         except Exception:
-            pass
+            log.debug("get_potential_energy() failed; falling back to atoms.info")
     return atoms.info.get("energy", 0.0)
 
 
@@ -180,7 +180,7 @@ def trajectory_to_landscape_df(
     the parallel force component.
     """
     try:
-        from rgpycrumbs._aux import _import_from_parent_env
+        from rgpycrumbs._aux import _import_from_parent_env  # noqa: PLC0415
 
         ira_mod = _import_from_parent_env("ira_mod")
         ira_instance = ira_mod.IRA()

--- a/chemparseplot/parse/trajectory/neb.py
+++ b/chemparseplot/parse/trajectory/neb.py
@@ -1,5 +1,8 @@
 """NEB trajectory parser for ASE-readable formats (extxyz, .traj, etc.).
 
+```{versionadded} 1.2.0
+```
+
 Loads trajectory files via ASE, computes NEB profile data (cumulative
 distance, improved Henkelman-Jonsson tangent forces), and converts into
 the formats expected by chemparseplot's plotting functions.
@@ -31,7 +34,11 @@ def _get_energy(atoms: Atoms) -> float:
 
 
 def load_trajectory(traj_file: str) -> list[Atoms]:
-    """Load an extxyz trajectory file, returning all frames."""
+    """Load an extxyz trajectory file, returning all frames.
+
+    ```{versionadded} 1.2.0
+    ```
+    """
     atoms_list = ase_read(traj_file, index=":")
     if isinstance(atoms_list, Atoms):
         atoms_list = [atoms_list]
@@ -41,6 +48,9 @@ def load_trajectory(traj_file: str) -> list[Atoms]:
 
 def compute_cumulative_distance(atoms_list: list[Atoms]) -> np.ndarray:
     """Compute cumulative Euclidean path length along the NEB band.
+
+    ```{versionadded} 1.2.0
+    ```
 
     Returns a 1D array of length n_images with the cumulative distance
     from the first image.
@@ -53,11 +63,12 @@ def compute_cumulative_distance(atoms_list: list[Atoms]) -> np.ndarray:
     return dists
 
 
-def compute_tangent_force(
-    atoms_list: list[Atoms], energies: np.ndarray
-) -> np.ndarray:
+def compute_tangent_force(atoms_list: list[Atoms], energies: np.ndarray) -> np.ndarray:
     """Compute force component parallel to the path using the improved
     Henkelman-Jonsson tangent definition.
+
+    ```{versionadded} 1.2.0
+    ```
 
     For interior images, the tangent is energy-weighted (uphill neighbor
     gets more weight). Forces are read from each frame's arrays.
@@ -68,7 +79,11 @@ def compute_tangent_force(
     f_para = np.zeros(n)
 
     for i in range(n):
-        forces_i = atoms_list[i].get_forces() if atoms_list[i].calc else np.zeros_like(atoms_list[i].positions)
+        forces_i = (
+            atoms_list[i].get_forces()
+            if atoms_list[i].calc
+            else np.zeros_like(atoms_list[i].positions)
+        )
 
         if i == 0 or i == n - 1:
             # Endpoint: f_parallel = 0 by convention
@@ -120,6 +135,9 @@ def extract_profile_data(
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Extract profile data from trajectory frames.
 
+    ```{versionadded} 1.2.0
+    ```
+
     Returns (index, distance, energy, f_parallel) arrays.
     """
     n = len(atoms_list)
@@ -132,6 +150,9 @@ def extract_profile_data(
 
 def trajectory_to_profile_dat(atoms_list: list[Atoms]) -> np.ndarray:
     """Convert trajectory to a (5, N) array matching eOn .dat layout.
+
+    ```{versionadded} 1.2.0
+    ```
 
     Columns: [index, reaction_coordinate, energy, f_parallel, zeros]
     This output can be fed directly into plot_energy_path as:
@@ -148,6 +169,9 @@ def trajectory_to_landscape_df(
     step: int = 0,
 ):
     """Convert trajectory to a polars DataFrame for plot_landscape_surface.
+
+    ```{versionadded} 1.2.0
+    ```
 
     Columns: r, p, grad_r, grad_p, z, step
 

--- a/chemparseplot/parse/trajectory/neb.py
+++ b/chemparseplot/parse/trajectory/neb.py
@@ -1,0 +1,172 @@
+"""NEB trajectory parser for ASE-readable formats (extxyz, .traj, etc.).
+
+Loads trajectory files via ASE, computes NEB profile data (cumulative
+distance, improved Henkelman-Jonsson tangent forces), and converts into
+the formats expected by chemparseplot's plotting functions.
+"""
+
+import logging
+
+import numpy as np
+from ase import Atoms
+from ase.io import read as ase_read
+
+from chemparseplot.parse.neb_utils import (
+    calculate_landscape_coords,
+    compute_synthetic_gradients,
+    create_landscape_dataframe,
+)
+
+log = logging.getLogger(__name__)
+
+
+def _get_energy(atoms: Atoms) -> float:
+    """Extract energy from an Atoms object, checking calc then info."""
+    if atoms.calc is not None:
+        try:
+            return atoms.get_potential_energy()
+        except Exception:
+            pass
+    return atoms.info.get("energy", 0.0)
+
+
+def load_trajectory(traj_file: str) -> list[Atoms]:
+    """Load an extxyz trajectory file, returning all frames."""
+    atoms_list = ase_read(traj_file, index=":")
+    if isinstance(atoms_list, Atoms):
+        atoms_list = [atoms_list]
+    log.info(f"Loaded {len(atoms_list)} frames from {traj_file}")
+    return atoms_list
+
+
+def compute_cumulative_distance(atoms_list: list[Atoms]) -> np.ndarray:
+    """Compute cumulative Euclidean path length along the NEB band.
+
+    Returns a 1D array of length n_images with the cumulative distance
+    from the first image.
+    """
+    n = len(atoms_list)
+    dists = np.zeros(n)
+    for i in range(1, n):
+        delta = atoms_list[i].positions - atoms_list[i - 1].positions
+        dists[i] = dists[i - 1] + np.linalg.norm(delta)
+    return dists
+
+
+def compute_tangent_force(
+    atoms_list: list[Atoms], energies: np.ndarray
+) -> np.ndarray:
+    """Compute force component parallel to the path using the improved
+    Henkelman-Jonsson tangent definition.
+
+    For interior images, the tangent is energy-weighted (uphill neighbor
+    gets more weight). Forces are read from each frame's arrays.
+
+    Returns a 1D array of f_parallel values (one per image).
+    """
+    n = len(atoms_list)
+    f_para = np.zeros(n)
+
+    for i in range(n):
+        forces_i = atoms_list[i].get_forces() if atoms_list[i].calc else np.zeros_like(atoms_list[i].positions)
+
+        if i == 0 or i == n - 1:
+            # Endpoint: f_parallel = 0 by convention
+            f_para[i] = 0.0
+            continue
+
+        # Tangent via improved H&J method
+        pos_prev = atoms_list[i - 1].positions.ravel()
+        pos_curr = atoms_list[i].positions.ravel()
+        pos_next = atoms_list[i + 1].positions.ravel()
+
+        tau_plus = pos_next - pos_curr
+        tau_minus = pos_curr - pos_prev
+
+        e_prev = energies[i - 1]
+        e_curr = energies[i]
+        e_next = energies[i + 1]
+
+        de_plus = e_next - e_curr
+        de_minus = e_curr - e_prev
+
+        if e_next > e_curr > e_prev:
+            tau = tau_plus
+        elif e_next < e_curr < e_prev:
+            tau = tau_minus
+        else:
+            # At extremum: energy-weighted bisection
+            de_max = max(abs(de_plus), abs(de_minus))
+            de_min = min(abs(de_plus), abs(de_minus))
+            if e_next > e_prev:
+                tau = tau_plus * de_max + tau_minus * de_min
+            else:
+                tau = tau_plus * de_min + tau_minus * de_max
+
+        tau_norm = np.linalg.norm(tau)
+        if tau_norm > 0:
+            tau_hat = tau / tau_norm
+        else:
+            tau_hat = tau
+
+        forces_flat = forces_i.ravel()
+        f_para[i] = np.dot(forces_flat, tau_hat)
+
+    return f_para
+
+
+def extract_profile_data(
+    atoms_list: list[Atoms],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Extract profile data from trajectory frames.
+
+    Returns (index, distance, energy, f_parallel) arrays.
+    """
+    n = len(atoms_list)
+    indices = np.arange(n, dtype=float)
+    distances = compute_cumulative_distance(atoms_list)
+    energies = np.array([_get_energy(a) for a in atoms_list])
+    f_para = compute_tangent_force(atoms_list, energies)
+    return indices, distances, energies, f_para
+
+
+def trajectory_to_profile_dat(atoms_list: list[Atoms]) -> np.ndarray:
+    """Convert trajectory to a (5, N) array matching eOn .dat layout.
+
+    Columns: [index, reaction_coordinate, energy, f_parallel, zeros]
+    This output can be fed directly into plot_energy_path as:
+        plot_energy_path(ax, data[1], data[2], data[3], ...)
+    """
+    indices, distances, energies, f_para = extract_profile_data(atoms_list)
+    zeros = np.zeros(len(atoms_list))
+    return np.array([indices, distances, energies, f_para, zeros])
+
+
+def trajectory_to_landscape_df(
+    atoms_list: list[Atoms],
+    ira_kmax: float = 1.8,
+    step: int = 0,
+):
+    """Convert trajectory to a polars DataFrame for plot_landscape_surface.
+
+    Columns: r, p, grad_r, grad_p, z, step
+
+    Uses RMSD from reactant (first frame) and product (last frame) as
+    the 2D coordinate system, with synthetic gradients projected from
+    the parallel force component.
+    """
+    try:
+        from rgpycrumbs._aux import _import_from_parent_env
+
+        ira_mod = _import_from_parent_env("ira_mod")
+        ira_instance = ira_mod.IRA()
+    except (ImportError, AttributeError):
+        ira_instance = None
+
+    rmsd_r, rmsd_p = calculate_landscape_coords(atoms_list, ira_instance, ira_kmax)
+
+    energies = np.array([_get_energy(a) for a in atoms_list])
+    f_para = compute_tangent_force(atoms_list, energies)
+
+    grad_r, grad_p = compute_synthetic_gradients(rmsd_r, rmsd_p, f_para)
+    return create_landscape_dataframe(rmsd_r, rmsd_p, grad_r, grad_p, energies, step)

--- a/chemparseplot/plot/geomscan.py
+++ b/chemparseplot/plot/geomscan.py
@@ -1,10 +1,15 @@
 import matplotlib.pyplot as plt
-
 from rgpycrumbs.interpolation import spline_interp
+
 from chemparseplot.plot.structs import BasePlotter
 
 
 def plot_energy_paths(energy_paths, units, colormap_fraction=1.0, plotter=None):
+    """Plot multiple energy paths with colormap-indexed colors.
+
+    ```{versionadded} 0.0.3
+    ```
+    """
     if plotter is None:
         plotter = BasePlotter()
 

--- a/chemparseplot/plot/neb.py
+++ b/chemparseplot/plot/neb.py
@@ -75,9 +75,7 @@ def render_structure_to_image(atoms, zoom, rotation):  # noqa: ARG001
     ```
     """
     buf = io.BytesIO()
-    ase_write(
-        buf, atoms, format="png", rotation=rotation, show_unit_cell=0, scale=100
-    )
+    ase_write(buf, atoms, format="png", rotation=rotation, show_unit_cell=0, scale=100)
     buf.seek(0)
     img_data = plt.imread(buf)
     buf.close()
@@ -115,11 +113,9 @@ def _render_xyzrender(atoms, canvas_size=400):
     numpy.ndarray
         RGBA image array with shape ``(H, W, 4)`` and float dtype.
     """
-    from ase.io import write as _ase_write
+    from ase.io import write as _ase_write  # noqa: PLC0415
 
-    with tempfile.NamedTemporaryFile(
-        suffix=".xyz", delete=False
-    ) as xyz_fh:
+    with tempfile.NamedTemporaryFile(suffix=".xyz", delete=False) as xyz_fh:
         xyz_path = xyz_fh.name
     png_path = xyz_path.rsplit(".", 1)[0] + ".png"
 
@@ -136,7 +132,7 @@ def _render_xyzrender(atoms, canvas_size=400):
         subprocess.run(cmd, check=True, capture_output=True)  # noqa: S603
         img_data = plt.imread(png_path)
     finally:
-        import os
+        import os  # noqa: PLC0415
 
         for p in (xyz_path, png_path):
             try:
@@ -531,10 +527,7 @@ def plot_landscape_surface(
         actual_nimags = None
 
     # --- 2. Hyperparameter Optimization ---
-    if (
-        method == "grad_imq"
-        and len(rmsd_r) > NYSTROM_THRESHOLD
-    ):
+    if method == "grad_imq" and len(rmsd_r) > NYSTROM_THRESHOLD:
         log.warning(
             "More than %d points, switching to Nystrom",
             NYSTROM_THRESHOLD,
@@ -542,8 +535,8 @@ def plot_landscape_surface(
         method = method + "_ny"
     model_class = get_surface_model(method)
     is_gradient_model = method.startswith("grad_")
-    _MIN_RBF_SMOOTH = 1e-4
-    h_ls = rbf_smooth if rbf_smooth and rbf_smooth > _MIN_RBF_SMOOTH else 0.5
+    _min_rbf_smooth = 1e-4
+    h_ls = rbf_smooth if rbf_smooth and rbf_smooth > _min_rbf_smooth else 0.5
     h_noise = 1e-2
 
     mask_opt = (

--- a/chemparseplot/plot/structs.py
+++ b/chemparseplot/plot/structs.py
@@ -2,16 +2,32 @@ from collections import namedtuple
 
 import matplotlib.pyplot as plt
 from cmcrameri import cm
-
 from rgpycrumbs.interpolation import spline_interp
 
 # Define a namedtuple for energy paths
 EnergyPath = namedtuple("EnergyPath", ["label", "distance", "energy"])
+"""Named tuple holding a labeled energy path (label, distance, energy).
+
+```{versionadded} 0.0.3
+```
+"""
+
 XYData = namedtuple("XYData", ["label", "x", "y"])
+"""Named tuple holding generic labeled XY data (label, x, y).
+
+```{versionadded} 0.0.3
+```
+"""
 
 
 # Baseline plotting class
 class BasePlotter:
+    """Thin wrapper around a matplotlib figure and axes with defaults.
+
+    ```{versionadded} 0.0.3
+    ```
+    """
+
     def __init__(
         self, figsize=(3.2, 2.5), dpi=200, pad=0.2, colormap=cm.batlow, style="bmh"
     ):
@@ -28,6 +44,12 @@ class BasePlotter:
 
 
 class TwoDimPlot(BasePlotter):
+    """Interactive 2D plotter with unit-aware axes and spline interpolation.
+
+    ```{versionadded} 0.0.3
+    ```
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.data = []  # Stores XYData objects

--- a/chemparseplot/plot/theme.py
+++ b/chemparseplot/plot/theme.py
@@ -1,3 +1,9 @@
+"""Plotting themes and colormap utilities.
+
+```{versionadded} 0.1.0
+```
+"""
+
 import logging
 from dataclasses import dataclass, replace
 
@@ -19,7 +25,11 @@ RUHI_COLORS = {
 
 @dataclass(frozen=True)
 class PlotTheme:
-    """Holds all aesthetic parameters for a matplotlib theme."""
+    """Holds all aesthetic parameters for a matplotlib theme.
+
+    ```{versionadded} 0.1.0
+    ```
+    """
 
     name: str
     font_family: str
@@ -67,7 +77,11 @@ THEMES = {
 
 
 def build_cmap(hex_list, name):
-    """Build and register a LinearSegmentedColormap from a list of hex colors."""
+    """Build and register a LinearSegmentedColormap from a list of hex colors.
+
+    ```{versionadded} 0.1.0
+    ```
+    """
     cols = [c.strip() for c in hex_list]
     cmap = LinearSegmentedColormap.from_list(name, cols, N=256)
     try:
@@ -102,7 +116,11 @@ build_cmap(
 
 
 def setup_global_theme(theme: PlotTheme):
-    """Sets global plt.rcParams based on the theme."""
+    """Sets global plt.rcParams based on the theme.
+
+    ```{versionadded} 0.1.0
+    ```
+    """
     log.info(f"Setting global rcParams for {theme.name} theme")
 
     font_family = theme.font_family
@@ -135,7 +153,11 @@ def setup_global_theme(theme: PlotTheme):
 
 
 def apply_axis_theme(ax: plt.Axes, theme: PlotTheme):
-    """Applies theme properties specific to an axis instance."""
+    """Applies theme properties specific to an axis instance.
+
+    ```{versionadded} 0.1.0
+    ```
+    """
     ax.set_facecolor(theme.facecolor)
     for spine in ax.spines.values():
         spine.set_edgecolor(theme.edgecolor)
@@ -147,6 +169,10 @@ def apply_axis_theme(ax: plt.Axes, theme: PlotTheme):
 
 
 def get_theme(name: str, **overrides) -> PlotTheme:
-    """Retrieves a theme by name and applies optional property overrides."""
+    """Retrieves a theme by name and applies optional property overrides.
+
+    ```{versionadded} 0.1.0
+    ```
+    """
     base = THEMES.get(name, RUHI_THEME)
     return replace(base, **{k: v for k, v in overrides.items() if v is not None})

--- a/chemparseplot/units.py
+++ b/chemparseplot/units.py
@@ -1,6 +1,12 @@
 # SPDX-FileCopyrightText: 2023-present Rohit Goswami <rog32@hi.is>
 #
 # SPDX-License-Identifier: MIT
+"""Unit registry and quantity helpers via pint.
+
+```{versionadded} 0.0.2
+```
+"""
+
 import warnings
 
 import pint

--- a/chemparseplot/util.py
+++ b/chemparseplot/util.py
@@ -65,30 +65,30 @@ def parse_target_coords(text_block):
 atoms = None
 try:
     # 1. Read the structure using ASE (handles format detection)
-    print(f"Reading {POSCON_FILENAME} using ASE...")
+    log.info("Reading %s using ASE...", POSCON_FILENAME)
     atoms = read(POSCON_FILENAME)
-    print(f"Successfully read {len(atoms)} atoms.")
+    log.info("Successfully read %d atoms.", len(atoms))
     atom_coords_from_poscon = atoms.get_positions()  # Get positions as NumPy array
 
 except FileNotFoundError:
-    print(f"Error: File not found at {POSCON_FILENAME}")
+    log.error("Error: File not found at %s", POSCON_FILENAME)
 except Exception as e:
-    print(f"Error reading {POSCON_FILENAME} with ASE: {e}")
+    log.error("Error reading %s with ASE: %s", POSCON_FILENAME, e)
 
 # 2. Parse the target coordinates
-print("Parsing target coordinates...")
+log.info("Parsing target coordinates...")
 target_coords = parse_target_coords(target_coords_text)
 
 # Proceed only if both steps were successful
 if atoms is not None and target_coords.size > 0:
-    print(f"\nFound {len(atom_coords_from_poscon)} atoms in {POSCON_FILENAME}.")
-    print(f"Found {len(target_coords)} target coordinates to match.")
+    log.info("Found %d atoms in %s.", len(atom_coords_from_poscon), POSCON_FILENAME)
+    log.info("Found %d target coordinates to match.", len(target_coords))
 
     results = []
     atom_symbols = atoms.get_chemical_symbols()  # Get symbols for richer output
 
     # 3. For each target coordinate, find the closest atom
-    print("\nMatching target coordinates to closest atoms...")
+    log.info("Matching target coordinates to closest atoms...")
     for i, target_pos in enumerate(target_coords):
         # Calculate distances (same numpy method)
         distances = np.linalg.norm(atom_coords_from_poscon - target_pos, axis=1)
@@ -112,19 +112,30 @@ if atoms is not None and target_coords.size > 0:
             }
         )
 
-    # 4. Print the results
-    print("\n--- Results ---")
+    # 4. Log the results
+    log.info("--- Results ---")
     for result in results:
-        print(
-            f"Target #{result['target_index']} ({result['target_pos'][0]:.4f}, {result['target_pos'][1]:.4f}, {result['target_pos'][2]:.4f})"
+        tp = result["target_pos"]
+        log.info(
+            "Target #%d (%.4f, %.4f, %.4f)",
+            result["target_index"],
+            tp[0],
+            tp[1],
+            tp[2],
         )
-        print(
-            f"  -> Closest Atom ID: {result['closest_atom_id']} (Symbol: {result['closest_atom_symbol']})"
+        log.info(
+            "  -> Closest Atom ID: %s (Symbol: %s)",
+            result["closest_atom_id"],
+            result["closest_atom_symbol"],
         )
-        print(
-            f"     Position: ({result['closest_atom_pos'][0]:.4f}, {result['closest_atom_pos'][1]:.4f}, {result['closest_atom_pos'][2]:.4f})"
+        cp = result["closest_atom_pos"]
+        log.info(
+            "     Position: (%.4f, %.4f, %.4f)",
+            cp[0],
+            cp[1],
+            cp[2],
         )
-        print(f"     Distance: {result['distance']:.6f}\n")
+        log.info("     Distance: %.6f", result["distance"])
 
 else:
-    print("\nAborted due to errors during parsing or file reading.")
+    log.warning("Aborted due to errors during parsing or file reading.")

--- a/doc/release/upcoming_changes/+docs.misc.md
+++ b/doc/release/upcoming_changes/+docs.misc.md
@@ -1,0 +1,1 @@
+Added versionadded directives to all public API docstrings and Zenodo DOI badge.

--- a/doc/release/upcoming_changes/+lint.misc.md
+++ b/doc/release/upcoming_changes/+lint.misc.md
@@ -1,0 +1,1 @@
+Applied ruff linting fixes across the codebase: replaced print with logging, fixed boolean positional args, exception formatting, and timezone awareness.

--- a/doc/release/upcoming_changes/+rmsd.changed.md
+++ b/doc/release/upcoming_changes/+rmsd.changed.md
@@ -1,0 +1,1 @@
+RMSD-R and RMSD-P landscape calculations now run concurrently for improved performance.

--- a/doc/release/upcoming_changes/+strip.changed.md
+++ b/doc/release/upcoming_changes/+strip.changed.md
@@ -1,0 +1,1 @@
+Uniform structure strip sizing via common bounding box across all rendered images.

--- a/doc/release/upcoming_changes/+traj.added.md
+++ b/doc/release/upcoming_changes/+traj.added.md
@@ -1,0 +1,1 @@
+Add generic trajectory NEB parser for ASE-readable formats (extxyz, .traj) via `chemparseplot.parse.trajectory.neb`.

--- a/doc/release/upcoming_changes/10.added.md
+++ b/doc/release/upcoming_changes/10.added.md
@@ -1,0 +1,1 @@
+Added optional xyzrender backend for structure strip rendering via renderer parameter.

--- a/doc/release/upcoming_changes/11.changed.md
+++ b/doc/release/upcoming_changes/11.changed.md
@@ -1,0 +1,1 @@
+Import `NYSTROM_THRESHOLD` from `rgpycrumbs.surfaces` instead of defining a local constant. The public API is unchanged; the threshold value (1000) is now maintained in one place.

--- a/doc/release/upcoming_changes/9.added.md
+++ b/doc/release/upcoming_changes/9.added.md
@@ -1,0 +1,4 @@
+Add HDF5 NEB reader for ChemGP output (`chemparseplot.parse.trajectory.hdf5`).
+Reads `neb_result.h5` and `neb_history.h5` files with pre-computed parallel
+forces and reaction coordinates. Also declares `h5py` as a dependency in the
+`neb` optional extra.

--- a/doc/source/apidocs/chemparseplot/chemparseplot.parse.eon.md
+++ b/doc/source/apidocs/chemparseplot/chemparseplot.parse.eon.md
@@ -1,0 +1,17 @@
+# {py:mod}`chemparseplot.parse.eon`
+
+```{py:module} chemparseplot.parse.eon
+```
+
+```{autodoc2-docstring} chemparseplot.parse.eon
+:allowtitles:
+```
+
+## Submodules
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+chemparseplot.parse.eon.neb
+```

--- a/doc/source/apidocs/chemparseplot/chemparseplot.parse.eon.neb.md
+++ b/doc/source/apidocs/chemparseplot/chemparseplot.parse.eon.neb.md
@@ -1,0 +1,42 @@
+# {py:mod}`chemparseplot.parse.eon.neb`
+
+```{py:module} chemparseplot.parse.eon.neb
+```
+
+```{autodoc2-docstring} chemparseplot.parse.eon.neb
+:allowtitles:
+```
+
+## Module Contents
+
+### Functions
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`load_or_compute_data <chemparseplot.parse.eon.neb.load_or_compute_data>`
+  - ```{autodoc2-docstring} chemparseplot.parse.eon.neb.load_or_compute_data
+    :summary:
+    ```
+* - {py:obj}`load_structures_and_calculate_additional_rmsd <chemparseplot.parse.eon.neb.load_structures_and_calculate_additional_rmsd>`
+  - ```{autodoc2-docstring} chemparseplot.parse.eon.neb.load_structures_and_calculate_additional_rmsd
+    :summary:
+    ```
+* - {py:obj}`aggregate_neb_landscape_data <chemparseplot.parse.eon.neb.aggregate_neb_landscape_data>`
+  - ```{autodoc2-docstring} chemparseplot.parse.eon.neb.aggregate_neb_landscape_data
+    :summary:
+    ```
+* - {py:obj}`load_augmenting_neb_data <chemparseplot.parse.eon.neb.load_augmenting_neb_data>`
+  - ```{autodoc2-docstring} chemparseplot.parse.eon.neb.load_augmenting_neb_data
+    :summary:
+    ```
+* - {py:obj}`compute_profile_rmsd <chemparseplot.parse.eon.neb.compute_profile_rmsd>`
+  - ```{autodoc2-docstring} chemparseplot.parse.eon.neb.compute_profile_rmsd
+    :summary:
+    ```
+* - {py:obj}`estimate_rbf_smoothing <chemparseplot.parse.eon.neb.estimate_rbf_smoothing>`
+  - ```{autodoc2-docstring} chemparseplot.parse.eon.neb.estimate_rbf_smoothing
+    :summary:
+    ```
+````

--- a/doc/source/apidocs/chemparseplot/chemparseplot.parse.md
+++ b/doc/source/apidocs/chemparseplot/chemparseplot.parse.md
@@ -1,0 +1,31 @@
+# {py:mod}`chemparseplot.parse`
+
+```{py:module} chemparseplot.parse
+```
+
+```{autodoc2-docstring} chemparseplot.parse
+:allowtitles:
+```
+
+## Subpackages
+
+```{toctree}
+:titlesonly:
+:maxdepth: 3
+
+chemparseplot.parse.eon
+chemparseplot.parse.orca
+chemparseplot.parse.trajectory
+```
+
+## Submodules
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+chemparseplot.parse.neb_utils
+chemparseplot.parse.patterns
+chemparseplot.parse.converter
+chemparseplot.parse.file_
+```

--- a/doc/source/apidocs/chemparseplot/chemparseplot.parse.neb_utils.md
+++ b/doc/source/apidocs/chemparseplot/chemparseplot.parse.neb_utils.md
@@ -1,0 +1,53 @@
+# {py:mod}`chemparseplot.parse.neb_utils`
+
+```{py:module} chemparseplot.parse.neb_utils
+```
+
+```{autodoc2-docstring} chemparseplot.parse.neb_utils
+:allowtitles:
+```
+
+## Module Contents
+
+### Functions
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`calculate_landscape_coords <chemparseplot.parse.neb_utils.calculate_landscape_coords>`
+  - ```{autodoc2-docstring} chemparseplot.parse.neb_utils.calculate_landscape_coords
+    :summary:
+    ```
+* - {py:obj}`compute_synthetic_gradients <chemparseplot.parse.neb_utils.compute_synthetic_gradients>`
+  - ```{autodoc2-docstring} chemparseplot.parse.neb_utils.compute_synthetic_gradients
+    :summary:
+    ```
+* - {py:obj}`create_landscape_dataframe <chemparseplot.parse.neb_utils.create_landscape_dataframe>`
+  - ```{autodoc2-docstring} chemparseplot.parse.neb_utils.create_landscape_dataframe
+    :summary:
+    ```
+````
+
+### API
+
+````{py:function} calculate_landscape_coords(atoms_list: list[ase.Atoms], ira_instance, ira_kmax: float) -> tuple[numpy.ndarray, numpy.ndarray]
+:canonical: chemparseplot.parse.neb_utils.calculate_landscape_coords
+
+```{autodoc2-docstring} chemparseplot.parse.neb_utils.calculate_landscape_coords
+```
+````
+
+````{py:function} compute_synthetic_gradients(rmsd_r: numpy.ndarray, rmsd_p: numpy.ndarray, f_para: numpy.ndarray) -> tuple[numpy.ndarray, numpy.ndarray]
+:canonical: chemparseplot.parse.neb_utils.compute_synthetic_gradients
+
+```{autodoc2-docstring} chemparseplot.parse.neb_utils.compute_synthetic_gradients
+```
+````
+
+````{py:function} create_landscape_dataframe(rmsd_r: numpy.ndarray, rmsd_p: numpy.ndarray, grad_r: numpy.ndarray, grad_p: numpy.ndarray, z: numpy.ndarray, step: int) -> polars.DataFrame
+:canonical: chemparseplot.parse.neb_utils.create_landscape_dataframe
+
+```{autodoc2-docstring} chemparseplot.parse.neb_utils.create_landscape_dataframe
+```
+````

--- a/doc/source/apidocs/chemparseplot/chemparseplot.parse.trajectory.hdf5.md
+++ b/doc/source/apidocs/chemparseplot/chemparseplot.parse.trajectory.hdf5.md
@@ -1,0 +1,86 @@
+# {py:mod}`chemparseplot.parse.trajectory.hdf5`
+
+```{py:module} chemparseplot.parse.trajectory.hdf5
+```
+
+```{autodoc2-docstring} chemparseplot.parse.trajectory.hdf5
+:allowtitles:
+```
+
+## Module Contents
+
+### Functions
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`load_neb_result <chemparseplot.parse.trajectory.hdf5.load_neb_result>`
+  - ```{autodoc2-docstring} chemparseplot.parse.trajectory.hdf5.load_neb_result
+    :summary:
+    ```
+* - {py:obj}`load_neb_history <chemparseplot.parse.trajectory.hdf5.load_neb_history>`
+  - ```{autodoc2-docstring} chemparseplot.parse.trajectory.hdf5.load_neb_history
+    :summary:
+    ```
+* - {py:obj}`result_to_profile_dat <chemparseplot.parse.trajectory.hdf5.result_to_profile_dat>`
+  - ```{autodoc2-docstring} chemparseplot.parse.trajectory.hdf5.result_to_profile_dat
+    :summary:
+    ```
+* - {py:obj}`result_to_atoms_list <chemparseplot.parse.trajectory.hdf5.result_to_atoms_list>`
+  - ```{autodoc2-docstring} chemparseplot.parse.trajectory.hdf5.result_to_atoms_list
+    :summary:
+    ```
+* - {py:obj}`history_to_profile_dats <chemparseplot.parse.trajectory.hdf5.history_to_profile_dats>`
+  - ```{autodoc2-docstring} chemparseplot.parse.trajectory.hdf5.history_to_profile_dats
+    :summary:
+    ```
+* - {py:obj}`history_to_landscape_df <chemparseplot.parse.trajectory.hdf5.history_to_landscape_df>`
+  - ```{autodoc2-docstring} chemparseplot.parse.trajectory.hdf5.history_to_landscape_df
+    :summary:
+    ```
+````
+
+### API
+
+````{py:function} load_neb_result(h5_file: str) -> dict
+:canonical: chemparseplot.parse.trajectory.hdf5.load_neb_result
+
+```{autodoc2-docstring} chemparseplot.parse.trajectory.hdf5.load_neb_result
+```
+````
+
+````{py:function} load_neb_history(h5_file: str) -> list[dict]
+:canonical: chemparseplot.parse.trajectory.hdf5.load_neb_history
+
+```{autodoc2-docstring} chemparseplot.parse.trajectory.hdf5.load_neb_history
+```
+````
+
+````{py:function} result_to_profile_dat(h5_file: str) -> numpy.ndarray
+:canonical: chemparseplot.parse.trajectory.hdf5.result_to_profile_dat
+
+```{autodoc2-docstring} chemparseplot.parse.trajectory.hdf5.result_to_profile_dat
+```
+````
+
+````{py:function} result_to_atoms_list(h5_file: str) -> list[ase.Atoms]
+:canonical: chemparseplot.parse.trajectory.hdf5.result_to_atoms_list
+
+```{autodoc2-docstring} chemparseplot.parse.trajectory.hdf5.result_to_atoms_list
+```
+````
+
+````{py:function} history_to_profile_dats(h5_file: str) -> list[numpy.ndarray]
+:canonical: chemparseplot.parse.trajectory.hdf5.history_to_profile_dats
+
+```{autodoc2-docstring} chemparseplot.parse.trajectory.hdf5.history_to_profile_dats
+```
+````
+
+````{py:function} history_to_landscape_df(h5_file: str, ira_kmax: float = 1.8)
+:canonical: chemparseplot.parse.trajectory.hdf5.history_to_landscape_df
+
+```{autodoc2-docstring} chemparseplot.parse.trajectory.hdf5.history_to_landscape_df
+```
+````

--- a/doc/source/apidocs/chemparseplot/chemparseplot.parse.trajectory.md
+++ b/doc/source/apidocs/chemparseplot/chemparseplot.parse.trajectory.md
@@ -1,0 +1,17 @@
+# {py:mod}`chemparseplot.parse.trajectory`
+
+```{py:module} chemparseplot.parse.trajectory
+```
+
+```{autodoc2-docstring} chemparseplot.parse.trajectory
+:allowtitles:
+```
+
+## Submodules
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+chemparseplot.parse.trajectory.neb
+```

--- a/doc/source/apidocs/chemparseplot/chemparseplot.parse.trajectory.md
+++ b/doc/source/apidocs/chemparseplot/chemparseplot.parse.trajectory.md
@@ -13,5 +13,6 @@
 :titlesonly:
 :maxdepth: 1
 
+chemparseplot.parse.trajectory.hdf5
 chemparseplot.parse.trajectory.neb
 ```

--- a/doc/source/apidocs/chemparseplot/chemparseplot.parse.trajectory.neb.md
+++ b/doc/source/apidocs/chemparseplot/chemparseplot.parse.trajectory.neb.md
@@ -1,0 +1,86 @@
+# {py:mod}`chemparseplot.parse.trajectory.neb`
+
+```{py:module} chemparseplot.parse.trajectory.neb
+```
+
+```{autodoc2-docstring} chemparseplot.parse.trajectory.neb
+:allowtitles:
+```
+
+## Module Contents
+
+### Functions
+
+````{list-table}
+:class: autosummary longtable
+:align: left
+
+* - {py:obj}`load_trajectory <chemparseplot.parse.trajectory.neb.load_trajectory>`
+  - ```{autodoc2-docstring} chemparseplot.parse.trajectory.neb.load_trajectory
+    :summary:
+    ```
+* - {py:obj}`compute_cumulative_distance <chemparseplot.parse.trajectory.neb.compute_cumulative_distance>`
+  - ```{autodoc2-docstring} chemparseplot.parse.trajectory.neb.compute_cumulative_distance
+    :summary:
+    ```
+* - {py:obj}`compute_tangent_force <chemparseplot.parse.trajectory.neb.compute_tangent_force>`
+  - ```{autodoc2-docstring} chemparseplot.parse.trajectory.neb.compute_tangent_force
+    :summary:
+    ```
+* - {py:obj}`extract_profile_data <chemparseplot.parse.trajectory.neb.extract_profile_data>`
+  - ```{autodoc2-docstring} chemparseplot.parse.trajectory.neb.extract_profile_data
+    :summary:
+    ```
+* - {py:obj}`trajectory_to_profile_dat <chemparseplot.parse.trajectory.neb.trajectory_to_profile_dat>`
+  - ```{autodoc2-docstring} chemparseplot.parse.trajectory.neb.trajectory_to_profile_dat
+    :summary:
+    ```
+* - {py:obj}`trajectory_to_landscape_df <chemparseplot.parse.trajectory.neb.trajectory_to_landscape_df>`
+  - ```{autodoc2-docstring} chemparseplot.parse.trajectory.neb.trajectory_to_landscape_df
+    :summary:
+    ```
+````
+
+### API
+
+````{py:function} load_trajectory(traj_file: str) -> list[ase.Atoms]
+:canonical: chemparseplot.parse.trajectory.neb.load_trajectory
+
+```{autodoc2-docstring} chemparseplot.parse.trajectory.neb.load_trajectory
+```
+````
+
+````{py:function} compute_cumulative_distance(atoms_list: list[ase.Atoms]) -> numpy.ndarray
+:canonical: chemparseplot.parse.trajectory.neb.compute_cumulative_distance
+
+```{autodoc2-docstring} chemparseplot.parse.trajectory.neb.compute_cumulative_distance
+```
+````
+
+````{py:function} compute_tangent_force(atoms_list: list[ase.Atoms], energies: numpy.ndarray) -> numpy.ndarray
+:canonical: chemparseplot.parse.trajectory.neb.compute_tangent_force
+
+```{autodoc2-docstring} chemparseplot.parse.trajectory.neb.compute_tangent_force
+```
+````
+
+````{py:function} extract_profile_data(atoms_list: list[ase.Atoms]) -> tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray, numpy.ndarray]
+:canonical: chemparseplot.parse.trajectory.neb.extract_profile_data
+
+```{autodoc2-docstring} chemparseplot.parse.trajectory.neb.extract_profile_data
+```
+````
+
+````{py:function} trajectory_to_profile_dat(atoms_list: list[ase.Atoms]) -> numpy.ndarray
+:canonical: chemparseplot.parse.trajectory.neb.trajectory_to_profile_dat
+
+```{autodoc2-docstring} chemparseplot.parse.trajectory.neb.trajectory_to_profile_dat
+```
+````
+
+````{py:function} trajectory_to_landscape_df(atoms_list: list[ase.Atoms], ira_kmax: float = 1.8, step: int = 0)
+:canonical: chemparseplot.parse.trajectory.neb.trajectory_to_landscape_df
+
+```{autodoc2-docstring} chemparseplot.parse.trajectory.neb.trajectory_to_landscape_df
+```
+````

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -6,7 +6,7 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 project = "chemparseplot"
-project_copyright = f"2023-2026, Rohit Goswami"
+project_copyright = "2023-2026, Rohit Goswami"
 author = "Rohit Goswami"
 # The short X.Y version.
 version = "1.1.0"

--- a/doc/source/installation.md
+++ b/doc/source/installation.md
@@ -32,4 +32,4 @@ codes which is required, not the codes themselves.
 
 - `ORCA` can be obtained (freely) after [registering on their forum](https://orcaforum.kofo.mpg.de/app.php/portal)
 - `ASE`, the [atomic simulation environment](https://wiki.fysik.dtu.dk/ase/), is also on PyPI and can be installed via `pip`
-- `eON` is [freely available](https://eondocs.org/) and on `conda-forge`. 
+- `eON` is [freely available](https://eondocs.org/) and on `conda-forge`.

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,50 @@
+exclude = """(?x)(
+    ^\\.pixi/|
+    ^\\.uv/|
+    ^docs/build/|
+    ^docs/source/_static/favicons/site\\.webmanifest$|
+    ^.*.svg$
+)"""
+
+# Prek implements these directly.
+[[repos]]
+hooks = [
+  { id = "trailing-whitespace" },
+  { id = "end-of-file-fixer" },
+  { id = "check-yaml" },
+  { id = "check-toml" },
+  { id = "check-added-large-files", args = [
+    "--maxkb=1000",
+  ] },
+  { id = "check-merge-conflict" },
+]
+repo = "builtin"
+[[repos]]
+hooks = [
+  { id = "check-ast" },
+  { id = "debug-statements" },
+  { id = "check-case-conflict" },
+]
+repo = "https://github.com/pre-commit/pre-commit-hooks"
+rev = "v6.0.0"
+[[repos]]
+hooks = [
+  { id = "ruff", args = [
+    "--fix",
+  ], types_or = [
+    "python",
+  ] },
+  { id = "ruff-format", types_or = [
+    "python",
+  ] },
+]
+repo = "https://github.com/astral-sh/ruff-pre-commit"
+rev = "v0.15.2"
+[[repos]]
+hooks = [ { id = "taplo-format" } ]
+repo  = "https://github.com/ComPWA/taplo-pre-commit"
+rev   = "v0.9.3"
+[[repos]]
+hooks = [ { id = "codespell", args = [ "--skip=*.lock,*.csv" ] } ]
+repo  = "https://github.com/codespell-project/codespell"
+rev   = "v2.4.1"

--- a/prek.toml
+++ b/prek.toml
@@ -41,10 +41,10 @@ hooks = [
 repo = "https://github.com/astral-sh/ruff-pre-commit"
 rev = "v0.15.2"
 [[repos]]
-hooks = [ { id = "taplo-format" } ]
-repo  = "https://github.com/ComPWA/taplo-pre-commit"
-rev   = "v0.9.3"
+hooks = [{ id = "taplo-format" }]
+repo = "https://github.com/ComPWA/taplo-pre-commit"
+rev = "v0.9.3"
 [[repos]]
-hooks = [ { id = "codespell", args = [ "--skip=*.lock,*.csv" ] } ]
-repo  = "https://github.com/codespell-project/codespell"
-rev   = "v2.4.1"
+hooks = [{ id = "codespell", args = ["--skip=*.lock,*.csv"] }]
+repo = "https://github.com/codespell-project/codespell"
+rev = "v2.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,34 +1,21 @@
 [build-system]
 build-backend = "hatchling.build"
-requires = [
-  "hatch-vcs",
-  "hatchling",
-]
+requires = ["hatch-vcs", "hatchling"]
 
 [tool.hatch.build.hooks.vcs]
 version-file = "_version.py"
 
 [tool.hatch.build]
-include = [
-  "chemparseplot/**/*.py",
-  "chemparseplot/*.py",
-  "/tests",
-]
+include = ["chemparseplot/**/*.py", "chemparseplot/*.py", "/tests"]
 
 
 [project]
 name = "chemparseplot"
 description = "Parsers and plotting tools for computational chemistry"
 readme = "readme.md"
-keywords = [
-  "compchem",
-  "parser",
-  "plot",
-]
-license = {text = "MIT"}
-authors = [
-    { name = "Rohit Goswami", email = "rog32@hi.is" },
-]
+keywords = ["compchem", "parser", "plot"]
+license = { text = "MIT" }
+authors = [{ name = "Rohit Goswami", email = "rog32@hi.is" }]
 requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 4 - Beta",
@@ -39,14 +26,8 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
-dynamic = [
-  "version",
-]
-dependencies = [
-  "numpy>=1.26.2",
-  "pint>=0.22",
-  "rgpycrumbs>=1.1.0",
-]
+dynamic = ["version"]
+dependencies = ["numpy>=1.26.2", "pint>=0.22", "rgpycrumbs>=1.1.0"]
 
 [project.optional-dependencies]
 doc = [
@@ -61,22 +42,11 @@ doc = [
   "sphinx-togglebutton>=0.3.2",
   "sphinxcontrib-apidoc>=0.4",
 ]
-plot = [
-  "cmcrameri>=1.7",
-  "matplotlib>=3.8.2",
-]
-neb = [
-  "ase>=3.22",
-  "h5py>=3.0",
-  "polars>=0.20",
-]
-test = [
-  "pytest>=7.4.3",
-  "pytest-cov>=4.1.0",
-]
-lint = [
-  "ruff>=0.1.6",
-]
+plot = ["cmcrameri>=1.7", "matplotlib>=3.8.2"]
+neb = ["ase>=3.22", "h5py>=3.0", "polars>=0.20"]
+xyzrender = ["xyzrender>=0.1.3"]
+test = ["pytest>=7.4.3", "pytest-cov>=4.1.0"]
+lint = ["ruff>=0.1.6"]
 [project.urls]
 Documentation = "https://github.com/HaoZeke/chemparseplot#readme"
 Issues = "https://github.com/HaoZeke/chemparseplot/issues"
@@ -136,9 +106,15 @@ ignore = [
   # Allow boolean positional values in function calls, like `dict.get(... True)`
   "FBT003",
   # Ignore checks for possible passwords
-  "S105", "S106", "S107",
+  "S105",
+  "S106",
+  "S107",
   # Ignore complexity
-  "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
+  "C901",
+  "PLR0911",
+  "PLR0912",
+  "PLR0913",
+  "PLR0915",
 ]
 unfixable = [
   # Don't touch unused imports
@@ -161,20 +137,14 @@ ban-relative-imports = "all"
 source_pkgs = ["chemparseplot"]
 branch = true
 parallel = true
-omit = [
-  "_version.py",
-]
+omit = ["_version.py"]
 
 [tool.coverage.paths]
 chemparseplot = ["src/chemparseplot", "*/chemparseplot/src/chemparseplot"]
 tests = ["tests"]
 
 [tool.coverage.report]
-exclude_lines = [
-  "no cov",
-  "if __name__ == .__main__.:",
-  "if TYPE_CHECKING:",
-]
+exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 
 [tool.towncrier]
 start_string = "<!-- towncrier release notes start -->\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dynamic = ["version"]
-dependencies = ["numpy>=1.26.2", "pint>=0.22", "rgpycrumbs>=1.1.0"]
+dependencies = ["numpy>=1.26.2", "pint>=0.22", "rgpycrumbs>=1.2.0"]
 
 [project.optional-dependencies]
 doc = [
@@ -44,7 +44,7 @@ doc = [
 ]
 plot = ["cmcrameri>=1.7", "matplotlib>=3.8.2"]
 neb = ["ase>=3.22", "h5py>=3.0", "polars>=0.20"]
-xyzrender = ["xyzrender>=0.1.3"]
+xyzrender = ["xyzrender>=0.1.2"]
 test = ["pytest>=7.4.3", "pytest-cov>=4.1.0"]
 lint = ["ruff>=0.1.6"]
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ plot = [
 ]
 neb = [
   "ase>=3.22",
+  "h5py>=3.0",
   "polars>=0.20",
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,10 @@ plot = [
   "cmcrameri>=1.7",
   "matplotlib>=3.8.2",
 ]
+neb = [
+  "ase>=3.22",
+  "polars>=0.20",
+]
 test = [
   "pytest>=7.4.3",
   "pytest-cov>=4.1.0",
@@ -82,6 +86,15 @@ rgpycrumbs = { git = "https://github.com/HaoZeke/rgpycrumbs" }
 
 [tool.hatch.version]
 source = "vcs"
+
+[tool.pytest.ini_options]
+addopts = ["-ra", "-q"]
+markers = [
+  "pure: mark a test as needing only numpy",
+  "neb: mark a test as needing numpy, polars, and ase",
+]
+minversion = "7.4"
+testpaths = ["tests"]
 
 [tool.ruff]
 target-version = "py312"

--- a/readme_src.org
+++ b/readme_src.org
@@ -4,6 +4,7 @@
 file:branding/logo/chemparseplot_logo.png
 #+begin_export markdown
 [![Hatch project](https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg)](https://github.com/pypa/hatch)
+[![DOI](https://zenodo.org/badge/725730118.svg)](https://doi.org/10.5281/zenodo.18529752)
 #+end_export
 A *pure-python*[fn:butwhy] project to provide unit-aware uniform visualizations
 of common computational chemistry tasks. Essentially this means we provide:
@@ -44,7 +45,7 @@ Also I couldn't find (m)any scripts using the scientific colorschemes.
 * License
 MIT. However, this is an academic resource, so *please cite* as much as possible
 via:
-- The Zenodo DOI for general use.
+- The [[https://doi.org/10.5281/zenodo.18529752][Zenodo DOI]] for general use.
 - The ~wailord~ paper for ORCA usage
 
 [fn:butwhy] To distinguish it from my other thin-python wrapper projects

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2023-present Rohit Goswami <rog32@hi.is>
+#
+# SPDX-License-Identifier: MIT
+import importlib.util
+
+import pytest
+
+# Define the requirements for each suite/marker
+ENVIRONMENT_REQUIREMENTS = {
+    "pure": ["numpy"],
+    "neb": ["numpy", "polars", "ase"],
+}
+
+
+def check_missing_modules(marker_name):
+    """Returns a list of missing modules for a given marker."""
+    modules = ENVIRONMENT_REQUIREMENTS.get(marker_name, [])
+    return [mod for mod in modules if importlib.util.find_spec(mod) is None]
+
+
+def skip_if_not_env(marker_name):
+    """Skips the entire module if dependencies for the marker remain uninstalled."""
+    missing = check_missing_modules(marker_name)
+    if missing:
+        pytest.skip(
+            f"Missing dependencies for '{marker_name}': {', '.join(missing)}",
+            allow_module_level=True,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 # Define the requirements for each suite/marker
 ENVIRONMENT_REQUIREMENTS = {
     "pure": ["numpy"],
-    "neb": ["numpy", "polars", "ase", "h5py"],
+    "neb": ["numpy", "polars", "ase", "h5py", "scipy", "matplotlib"],
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 # Define the requirements for each suite/marker
 ENVIRONMENT_REQUIREMENTS = {
     "pure": ["numpy"],
-    "neb": ["numpy", "polars", "ase"],
+    "neb": ["numpy", "polars", "ase", "h5py"],
 }
 
 

--- a/tests/parse/orca/test_interp.py
+++ b/tests/parse/orca/test_interp.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 from rgpycrumbs.basetypes import nebiter
+
 from chemparseplot.parse.orca.neb.interp import extract_interp_points
 from chemparseplot.units import ureg
 

--- a/tests/parse/test_neb_utils.py
+++ b/tests/parse/test_neb_utils.py
@@ -89,7 +89,11 @@ class TestCreateLandscapeDataframe:
     def test_step_is_constant(self):
         n = 4
         df = create_landscape_dataframe(
-            np.zeros(n), np.zeros(n), np.zeros(n),
-            np.zeros(n), np.zeros(n), step=7,
+            np.zeros(n),
+            np.zeros(n),
+            np.zeros(n),
+            np.zeros(n),
+            np.zeros(n),
+            step=7,
         )
         assert all(s == 7 for s in df["step"].to_list())

--- a/tests/parse/test_neb_utils.py
+++ b/tests/parse/test_neb_utils.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2023-present Rohit Goswami <rog32@hi.is>
+#
+# SPDX-License-Identifier: MIT
+import numpy as np
+import pytest
+
+from tests.conftest import skip_if_not_env
+
+skip_if_not_env("neb")
+
+from chemparseplot.parse.neb_utils import (  # noqa: E402
+    compute_synthetic_gradients,
+    create_landscape_dataframe,
+)
+
+pytestmark = pytest.mark.neb
+
+
+class TestComputeSyntheticGradients:
+    """Tests for the synthetic 2D gradient projection."""
+
+    def test_zero_force_gives_zero_gradients(self):
+        rmsd_r = np.array([0.0, 1.0, 2.0, 3.0])
+        rmsd_p = np.array([3.0, 2.0, 1.0, 0.0])
+        f_para = np.zeros(4)
+        grad_r, grad_p = compute_synthetic_gradients(rmsd_r, rmsd_p, f_para)
+        np.testing.assert_array_equal(grad_r, np.zeros(4))
+        np.testing.assert_array_equal(grad_p, np.zeros(4))
+
+    def test_output_shape_matches_input(self):
+        n = 7
+        rmsd_r = np.linspace(0, 3, n)
+        rmsd_p = np.linspace(3, 0, n)
+        f_para = np.random.default_rng(42).standard_normal(n)
+        grad_r, grad_p = compute_synthetic_gradients(rmsd_r, rmsd_p, f_para)
+        assert grad_r.shape == (n,)
+        assert grad_p.shape == (n,)
+
+    def test_sign_convention(self):
+        """Positive f_para should yield negative gradients along the path."""
+        rmsd_r = np.array([0.0, 1.0, 2.0])
+        rmsd_p = np.array([2.0, 1.0, 0.0])
+        f_para = np.array([0.0, 1.0, 0.0])
+        grad_r, grad_p = compute_synthetic_gradients(rmsd_r, rmsd_p, f_para)
+        # Interior point: positive force -> negative gradient component
+        assert grad_r[1] < 0
+        assert grad_p[1] > 0  # rmsd_p decreases, so dp < 0, so -f*t_p > 0
+
+    def test_constant_rmsd_no_division_by_zero(self):
+        """When all RMSD values are identical, norm_ds=0 is handled."""
+        rmsd_r = np.ones(5)
+        rmsd_p = np.ones(5)
+        f_para = np.ones(5)
+        grad_r, grad_p = compute_synthetic_gradients(rmsd_r, rmsd_p, f_para)
+        assert not np.any(np.isnan(grad_r))
+        assert not np.any(np.isnan(grad_p))
+
+
+class TestCreateLandscapeDataframe:
+    """Tests for the landscape DataFrame factory."""
+
+    def test_schema(self):
+        n = 5
+        df = create_landscape_dataframe(
+            rmsd_r=np.zeros(n),
+            rmsd_p=np.zeros(n),
+            grad_r=np.zeros(n),
+            grad_p=np.zeros(n),
+            z=np.zeros(n),
+            step=0,
+        )
+        assert set(df.columns) == {"r", "p", "grad_r", "grad_p", "z", "step"}
+        assert df.height == n
+
+    def test_values_roundtrip(self):
+        r = np.array([0.0, 1.0, 2.0])
+        p = np.array([3.0, 2.0, 1.0])
+        gr = np.array([0.1, 0.2, 0.3])
+        gp = np.array([-0.1, -0.2, -0.3])
+        z = np.array([-1.0, 0.5, -0.8])
+        step = 3
+
+        df = create_landscape_dataframe(r, p, gr, gp, z, step)
+        np.testing.assert_array_almost_equal(df["r"].to_numpy(), r)
+        np.testing.assert_array_almost_equal(df["p"].to_numpy(), p)
+        np.testing.assert_array_almost_equal(df["z"].to_numpy(), z)
+        assert df["step"][0] == step
+
+    def test_step_is_constant(self):
+        n = 4
+        df = create_landscape_dataframe(
+            np.zeros(n), np.zeros(n), np.zeros(n),
+            np.zeros(n), np.zeros(n), step=7,
+        )
+        assert all(s == 7 for s in df["step"].to_list())

--- a/tests/parse/test_trajectory_hdf5.py
+++ b/tests/parse/test_trajectory_hdf5.py
@@ -6,6 +6,7 @@
 All HDF5 files are synthetic, created via h5py in fixtures -- no external
 test data files needed.
 """
+
 import numpy as np
 import pytest
 
@@ -65,9 +66,7 @@ def result_h5(tmp_path):
 
     with h5py.File(fpath, "w") as f:
         path_grp = f.create_group("path")
-        _write_path_group(
-            path_grp, images, energies, gradients, f_para, rxn_coord
-        )
+        _write_path_group(path_grp, images, energies, gradients, f_para, rxn_coord)
 
         conv_grp = f.create_group("convergence")
         conv_grp.create_dataset("max_force", data=np.array([0.5, 0.1, 0.01]))
@@ -76,9 +75,7 @@ def result_h5(tmp_path):
         meta_grp = f.create_group("metadata")
         meta_grp.create_dataset("converged", data=True)
         meta_grp.create_dataset("oracle_calls", data=30)
-        meta_grp.create_dataset(
-            "atomic_numbers", data=np.array([1, 6, 8])
-        )
+        meta_grp.create_dataset("atomic_numbers", data=np.array([1, 6, 8]))
 
     return str(fpath)
 
@@ -91,13 +88,9 @@ def result_h5_with_cell(tmp_path):
 
     with h5py.File(fpath, "w") as f:
         path_grp = f.create_group("path")
-        _write_path_group(
-            path_grp, images, energies, gradients, f_para, rxn_coord
-        )
+        _write_path_group(path_grp, images, energies, gradients, f_para, rxn_coord)
         meta_grp = f.create_group("metadata")
-        meta_grp.create_dataset(
-            "atomic_numbers", data=np.array([1, 6, 8])
-        )
+        meta_grp.create_dataset("atomic_numbers", data=np.array([1, 6, 8]))
         cell = np.eye(3).ravel() * 10.0
         meta_grp.create_dataset("cell", data=cell)
 
@@ -113,20 +106,14 @@ def history_h5(tmp_path):
     with h5py.File(fpath, "w") as f:
         steps_grp = f.create_group("steps")
         for i in range(n_steps):
-            images, energies, gradients, f_para, rxn_coord = (
-                _make_path_arrays()
-            )
+            images, energies, gradients, f_para, rxn_coord = _make_path_arrays()
             # Shift energies per step so they are distinguishable
             energies = energies + i * 0.1
             step_grp = steps_grp.create_group(str(i))
-            _write_path_group(
-                step_grp, images, energies, gradients, f_para, rxn_coord
-            )
+            _write_path_group(step_grp, images, energies, gradients, f_para, rxn_coord)
 
         meta_grp = f.create_group("metadata")
-        meta_grp.create_dataset(
-            "atomic_numbers", data=np.array([1, 6, 8])
-        )
+        meta_grp.create_dataset("atomic_numbers", data=np.array([1, 6, 8]))
 
     return str(fpath)
 
@@ -179,9 +166,7 @@ class TestReconstructAtoms:
         )
         for i, atoms in enumerate(atoms_list):
             expected_pos = images[i].reshape(N_ATOMS, 3)
-            np.testing.assert_array_almost_equal(
-                atoms.positions, expected_pos
-            )
+            np.testing.assert_array_almost_equal(atoms.positions, expected_pos)
 
     def test_energy_attached(self):
         images, energies, gradients, _, _ = _make_path_arrays()
@@ -189,9 +174,7 @@ class TestReconstructAtoms:
             images, np.array([1, 6, 8]), None, gradients, energies
         )
         for i, atoms in enumerate(atoms_list):
-            assert atoms.get_potential_energy() == pytest.approx(
-                energies[i]
-            )
+            assert atoms.get_potential_energy() == pytest.approx(energies[i])
 
     def test_forces_are_negative_gradients(self):
         images, energies, gradients, _, _ = _make_path_arrays()
@@ -200,15 +183,11 @@ class TestReconstructAtoms:
         )
         for i, atoms in enumerate(atoms_list):
             expected_forces = -gradients[i].reshape(N_ATOMS, 3)
-            np.testing.assert_array_almost_equal(
-                atoms.get_forces(), expected_forces
-            )
+            np.testing.assert_array_almost_equal(atoms.get_forces(), expected_forces)
 
     def test_default_atomic_numbers(self):
         images, energies, gradients, _, _ = _make_path_arrays()
-        atoms_list = _reconstruct_atoms(
-            images, None, None, gradients, energies
-        )
+        atoms_list = _reconstruct_atoms(images, None, None, gradients, energies)
         # Default is all hydrogen
         for atoms in atoms_list:
             assert all(z == 1 for z in atoms.numbers)
@@ -220,9 +199,7 @@ class TestReconstructAtoms:
             images, np.array([1, 6, 8]), cell, gradients, energies
         )
         for atoms in atoms_list:
-            np.testing.assert_array_almost_equal(
-                atoms.cell[:], np.eye(3) * 10.0
-            )
+            np.testing.assert_array_almost_equal(atoms.cell[:], np.eye(3) * 10.0)
             assert all(atoms.pbc)
 
 
@@ -233,9 +210,7 @@ class TestResultToProfileDat:
 
     def test_index_row(self, result_h5):
         data = result_to_profile_dat(result_h5)
-        np.testing.assert_array_equal(
-            data[0], np.arange(N_IMAGES, dtype=float)
-        )
+        np.testing.assert_array_equal(data[0], np.arange(N_IMAGES, dtype=float))
 
     def test_rxn_coord_matches_input(self, result_h5):
         _, _, _, _, rxn_coord = _make_path_arrays()
@@ -270,16 +245,12 @@ class TestResultToAtomsList:
     def test_atomic_numbers_from_metadata(self, result_h5):
         atoms_list = result_to_atoms_list(result_h5)
         for atoms in atoms_list:
-            np.testing.assert_array_equal(
-                atoms.numbers, [1, 6, 8]
-            )
+            np.testing.assert_array_equal(atoms.numbers, [1, 6, 8])
 
     def test_cell_from_metadata(self, result_h5_with_cell):
         atoms_list = result_to_atoms_list(result_h5_with_cell)
         for atoms in atoms_list:
-            np.testing.assert_array_almost_equal(
-                atoms.cell[:], np.eye(3) * 10.0
-            )
+            np.testing.assert_array_almost_equal(atoms.cell[:], np.eye(3) * 10.0)
 
 
 class TestLoadNebResult:
@@ -319,9 +290,7 @@ class TestLoadNebHistory:
     def test_energies_differ_across_steps(self, history_h5):
         steps = load_neb_history(history_h5)
         # We shifted energies by step_idx * 0.1
-        assert not np.allclose(
-            steps[0]["energies"], steps[2]["energies"]
-        )
+        assert not np.allclose(steps[0]["energies"], steps[2]["energies"])
 
 
 class TestHistoryToProfileDats:
@@ -337,6 +306,4 @@ class TestHistoryToProfileDats:
     def test_last_row_zeros(self, history_h5):
         dats = history_to_profile_dats(history_h5)
         for dat in dats:
-            np.testing.assert_array_equal(
-                dat[4], np.zeros(N_IMAGES)
-            )
+            np.testing.assert_array_equal(dat[4], np.zeros(N_IMAGES))

--- a/tests/parse/test_trajectory_hdf5.py
+++ b/tests/parse/test_trajectory_hdf5.py
@@ -1,0 +1,342 @@
+# SPDX-FileCopyrightText: 2023-present Rohit Goswami <rog32@hi.is>
+#
+# SPDX-License-Identifier: MIT
+"""Tests for the HDF5 NEB reader (ChemGP output).
+
+All HDF5 files are synthetic, created via h5py in fixtures -- no external
+test data files needed.
+"""
+import numpy as np
+import pytest
+
+from tests.conftest import skip_if_not_env
+
+skip_if_not_env("neb")
+
+import h5py  # noqa: E402
+
+from chemparseplot.parse.trajectory.hdf5 import (  # noqa: E402
+    _read_path_group,
+    _reconstruct_atoms,
+    history_to_profile_dats,
+    load_neb_history,
+    load_neb_result,
+    result_to_atoms_list,
+    result_to_profile_dat,
+)
+
+pytestmark = pytest.mark.neb
+
+# --- Helpers / Constants ---
+N_IMAGES = 5
+N_ATOMS = 3
+NDOF = N_ATOMS * 3
+
+
+def _make_path_arrays(n_images=N_IMAGES, n_atoms=N_ATOMS):
+    """Generate consistent synthetic path data."""
+    rng = np.random.default_rng(42)
+    ndof = n_atoms * 3
+    images = rng.random((n_images, ndof))
+    energies = np.linspace(0.0, 1.0, n_images)
+    gradients = rng.random((n_images, ndof)) * 0.1
+    f_para = rng.random(n_images) * 0.5
+    rxn_coord = np.linspace(0.0, 3.0, n_images)
+    return images, energies, gradients, f_para, rxn_coord
+
+
+def _write_path_group(grp, images, energies, gradients, f_para, rxn_coord):
+    """Write path arrays into an HDF5 group."""
+    grp.create_dataset("images", data=images)
+    grp.create_dataset("energies", data=energies)
+    grp.create_dataset("gradients", data=gradients)
+    grp.create_dataset("f_para", data=f_para)
+    grp.create_dataset("rxn_coord", data=rxn_coord)
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture()
+def result_h5(tmp_path):
+    """Create a synthetic neb_result.h5 file."""
+    fpath = tmp_path / "neb_result.h5"
+    images, energies, gradients, f_para, rxn_coord = _make_path_arrays()
+
+    with h5py.File(fpath, "w") as f:
+        path_grp = f.create_group("path")
+        _write_path_group(
+            path_grp, images, energies, gradients, f_para, rxn_coord
+        )
+
+        conv_grp = f.create_group("convergence")
+        conv_grp.create_dataset("max_force", data=np.array([0.5, 0.1, 0.01]))
+        conv_grp.create_dataset("oracle_calls", data=np.array([10, 20, 30]))
+
+        meta_grp = f.create_group("metadata")
+        meta_grp.create_dataset("converged", data=True)
+        meta_grp.create_dataset("oracle_calls", data=30)
+        meta_grp.create_dataset(
+            "atomic_numbers", data=np.array([1, 6, 8])
+        )
+
+    return str(fpath)
+
+
+@pytest.fixture()
+def result_h5_with_cell(tmp_path):
+    """Create a result file that includes a cell."""
+    fpath = tmp_path / "neb_result_cell.h5"
+    images, energies, gradients, f_para, rxn_coord = _make_path_arrays()
+
+    with h5py.File(fpath, "w") as f:
+        path_grp = f.create_group("path")
+        _write_path_group(
+            path_grp, images, energies, gradients, f_para, rxn_coord
+        )
+        meta_grp = f.create_group("metadata")
+        meta_grp.create_dataset(
+            "atomic_numbers", data=np.array([1, 6, 8])
+        )
+        cell = np.eye(3).ravel() * 10.0
+        meta_grp.create_dataset("cell", data=cell)
+
+    return str(fpath)
+
+
+@pytest.fixture()
+def history_h5(tmp_path):
+    """Create a synthetic neb_history.h5 file with 3 steps."""
+    fpath = tmp_path / "neb_history.h5"
+    n_steps = 3
+
+    with h5py.File(fpath, "w") as f:
+        steps_grp = f.create_group("steps")
+        for i in range(n_steps):
+            images, energies, gradients, f_para, rxn_coord = (
+                _make_path_arrays()
+            )
+            # Shift energies per step so they are distinguishable
+            energies = energies + i * 0.1
+            step_grp = steps_grp.create_group(str(i))
+            _write_path_group(
+                step_grp, images, energies, gradients, f_para, rxn_coord
+            )
+
+        meta_grp = f.create_group("metadata")
+        meta_grp.create_dataset(
+            "atomic_numbers", data=np.array([1, 6, 8])
+        )
+
+    return str(fpath)
+
+
+# --- Tests ---
+
+
+class TestReadPathGroup:
+    def test_returns_all_keys(self, result_h5):
+        with h5py.File(result_h5, "r") as f:
+            data = _read_path_group(f["path"])
+        assert set(data.keys()) == {
+            "images",
+            "energies",
+            "gradients",
+            "f_para",
+            "rxn_coord",
+        }
+
+    def test_array_shapes(self, result_h5):
+        with h5py.File(result_h5, "r") as f:
+            data = _read_path_group(f["path"])
+        assert data["images"].shape == (N_IMAGES, NDOF)
+        assert data["energies"].shape == (N_IMAGES,)
+        assert data["gradients"].shape == (N_IMAGES, NDOF)
+        assert data["f_para"].shape == (N_IMAGES,)
+        assert data["rxn_coord"].shape == (N_IMAGES,)
+
+    def test_values_are_numpy(self, result_h5):
+        with h5py.File(result_h5, "r") as f:
+            data = _read_path_group(f["path"])
+        for v in data.values():
+            assert isinstance(v, np.ndarray)
+
+
+class TestReconstructAtoms:
+    def test_correct_atom_count(self):
+        images, energies, gradients, _, _ = _make_path_arrays()
+        atoms_list = _reconstruct_atoms(
+            images, np.array([1, 6, 8]), None, gradients, energies
+        )
+        assert len(atoms_list) == N_IMAGES
+        for atoms in atoms_list:
+            assert len(atoms) == N_ATOMS
+
+    def test_positions_match(self):
+        images, energies, gradients, _, _ = _make_path_arrays()
+        atoms_list = _reconstruct_atoms(
+            images, np.array([1, 6, 8]), None, gradients, energies
+        )
+        for i, atoms in enumerate(atoms_list):
+            expected_pos = images[i].reshape(N_ATOMS, 3)
+            np.testing.assert_array_almost_equal(
+                atoms.positions, expected_pos
+            )
+
+    def test_energy_attached(self):
+        images, energies, gradients, _, _ = _make_path_arrays()
+        atoms_list = _reconstruct_atoms(
+            images, np.array([1, 6, 8]), None, gradients, energies
+        )
+        for i, atoms in enumerate(atoms_list):
+            assert atoms.get_potential_energy() == pytest.approx(
+                energies[i]
+            )
+
+    def test_forces_are_negative_gradients(self):
+        images, energies, gradients, _, _ = _make_path_arrays()
+        atoms_list = _reconstruct_atoms(
+            images, np.array([1, 6, 8]), None, gradients, energies
+        )
+        for i, atoms in enumerate(atoms_list):
+            expected_forces = -gradients[i].reshape(N_ATOMS, 3)
+            np.testing.assert_array_almost_equal(
+                atoms.get_forces(), expected_forces
+            )
+
+    def test_default_atomic_numbers(self):
+        images, energies, gradients, _, _ = _make_path_arrays()
+        atoms_list = _reconstruct_atoms(
+            images, None, None, gradients, energies
+        )
+        # Default is all hydrogen
+        for atoms in atoms_list:
+            assert all(z == 1 for z in atoms.numbers)
+
+    def test_cell_attached(self):
+        images, energies, gradients, _, _ = _make_path_arrays()
+        cell = np.eye(3).ravel() * 10.0
+        atoms_list = _reconstruct_atoms(
+            images, np.array([1, 6, 8]), cell, gradients, energies
+        )
+        for atoms in atoms_list:
+            np.testing.assert_array_almost_equal(
+                atoms.cell[:], np.eye(3) * 10.0
+            )
+            assert all(atoms.pbc)
+
+
+class TestResultToProfileDat:
+    def test_shape(self, result_h5):
+        data = result_to_profile_dat(result_h5)
+        assert data.shape == (5, N_IMAGES)
+
+    def test_index_row(self, result_h5):
+        data = result_to_profile_dat(result_h5)
+        np.testing.assert_array_equal(
+            data[0], np.arange(N_IMAGES, dtype=float)
+        )
+
+    def test_rxn_coord_matches_input(self, result_h5):
+        _, _, _, _, rxn_coord = _make_path_arrays()
+        data = result_to_profile_dat(result_h5)
+        np.testing.assert_array_almost_equal(data[1], rxn_coord)
+
+    def test_energies_match_input(self, result_h5):
+        _, energies, _, _, _ = _make_path_arrays()
+        data = result_to_profile_dat(result_h5)
+        np.testing.assert_array_almost_equal(data[2], energies)
+
+    def test_f_para_matches_input(self, result_h5):
+        _, _, _, f_para, _ = _make_path_arrays()
+        data = result_to_profile_dat(result_h5)
+        np.testing.assert_array_almost_equal(data[3], f_para)
+
+    def test_last_row_is_zeros(self, result_h5):
+        data = result_to_profile_dat(result_h5)
+        np.testing.assert_array_equal(data[4], np.zeros(N_IMAGES))
+
+
+class TestResultToAtomsList:
+    def test_returns_correct_count(self, result_h5):
+        atoms_list = result_to_atoms_list(result_h5)
+        assert len(atoms_list) == N_IMAGES
+
+    def test_atoms_have_calculator(self, result_h5):
+        atoms_list = result_to_atoms_list(result_h5)
+        for atoms in atoms_list:
+            assert atoms.calc is not None
+
+    def test_atomic_numbers_from_metadata(self, result_h5):
+        atoms_list = result_to_atoms_list(result_h5)
+        for atoms in atoms_list:
+            np.testing.assert_array_equal(
+                atoms.numbers, [1, 6, 8]
+            )
+
+    def test_cell_from_metadata(self, result_h5_with_cell):
+        atoms_list = result_to_atoms_list(result_h5_with_cell)
+        for atoms in atoms_list:
+            np.testing.assert_array_almost_equal(
+                atoms.cell[:], np.eye(3) * 10.0
+            )
+
+
+class TestLoadNebResult:
+    def test_has_expected_keys(self, result_h5):
+        result = load_neb_result(result_h5)
+        assert "path" in result
+        assert "convergence" in result
+        assert "metadata" in result
+
+    def test_convergence_data(self, result_h5):
+        result = load_neb_result(result_h5)
+        assert "max_force" in result["convergence"]
+        assert len(result["convergence"]["max_force"]) == 3
+
+    def test_metadata_scalars(self, result_h5):
+        result = load_neb_result(result_h5)
+        assert result["metadata"]["converged"] == True  # noqa: E712
+        assert result["metadata"]["oracle_calls"] == 30
+
+
+class TestLoadNebHistory:
+    def test_returns_sorted_steps(self, history_h5):
+        steps = load_neb_history(history_h5)
+        assert len(steps) == 3
+
+    def test_step_data_structure(self, history_h5):
+        steps = load_neb_history(history_h5)
+        for step in steps:
+            assert set(step.keys()) == {
+                "images",
+                "energies",
+                "gradients",
+                "f_para",
+                "rxn_coord",
+            }
+
+    def test_energies_differ_across_steps(self, history_h5):
+        steps = load_neb_history(history_h5)
+        # We shifted energies by step_idx * 0.1
+        assert not np.allclose(
+            steps[0]["energies"], steps[2]["energies"]
+        )
+
+
+class TestHistoryToProfileDats:
+    def test_one_array_per_step(self, history_h5):
+        dats = history_to_profile_dats(history_h5)
+        assert len(dats) == 3
+
+    def test_array_shape(self, history_h5):
+        dats = history_to_profile_dats(history_h5)
+        for dat in dats:
+            assert dat.shape == (5, N_IMAGES)
+
+    def test_last_row_zeros(self, history_h5):
+        dats = history_to_profile_dats(history_h5)
+        for dat in dats:
+            np.testing.assert_array_equal(
+                dat[4], np.zeros(N_IMAGES)
+            )

--- a/tests/parse/test_trajectory_neb.py
+++ b/tests/parse/test_trajectory_neb.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: 2023-present Rohit Goswami <rog32@hi.is>
+#
+# SPDX-License-Identifier: MIT
+"""Tests for the trajectory NEB parser.
+
+The physics computations (cumulative distance, tangent forces) are validated
+against hand-calculated reference values.
+"""
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from tests.conftest import skip_if_not_env
+
+skip_if_not_env("neb")
+
+from ase import Atoms  # noqa: E402
+
+from chemparseplot.parse.trajectory.neb import (  # noqa: E402
+    _get_energy,
+    compute_cumulative_distance,
+    compute_tangent_force,
+    extract_profile_data,
+    load_trajectory,
+    trajectory_to_profile_dat,
+)
+
+pytestmark = pytest.mark.neb
+
+
+def _make_atoms(positions, energy=0.0, forces=None):
+    """Create an ASE Atoms object with attached energy and optional forces.
+
+    Uses a SinglePointCalculator when forces are provided so that
+    atoms.get_forces() and atoms.get_potential_energy() work correctly.
+    """
+    atoms = Atoms("H" * len(positions), positions=positions)
+    if forces is not None:
+        from ase.calculators.singlepoint import SinglePointCalculator
+
+        calc = SinglePointCalculator(atoms, energy=energy, forces=forces)
+        atoms.calc = calc
+    else:
+        atoms.info["energy"] = energy
+    return atoms
+
+
+class TestGetEnergy:
+    def test_energy_from_info(self):
+        atoms = _make_atoms([[0, 0, 0]], energy=-1.5)
+        assert _get_energy(atoms) == -1.5
+
+    def test_energy_from_calc(self):
+        atoms = _make_atoms(
+            [[0, 0, 0]], energy=-2.0, forces=[[0, 0, 0]]
+        )
+        assert _get_energy(atoms) == -2.0
+
+    def test_energy_fallback_zero(self):
+        atoms = Atoms("H", positions=[[0, 0, 0]])
+        assert _get_energy(atoms) == 0.0
+
+
+class TestComputeCumulativeDistance:
+    def test_single_image(self):
+        atoms_list = [_make_atoms([[0, 0, 0]])]
+        dists = compute_cumulative_distance(atoms_list)
+        assert len(dists) == 1
+        assert dists[0] == 0.0
+
+    def test_linear_path(self):
+        # Three atoms along x-axis, 1 angstrom apart
+        atoms_list = [
+            _make_atoms([[0, 0, 0]]),
+            _make_atoms([[1, 0, 0]]),
+            _make_atoms([[2, 0, 0]]),
+        ]
+        dists = compute_cumulative_distance(atoms_list)
+        np.testing.assert_array_almost_equal(dists, [0.0, 1.0, 2.0])
+
+    def test_cumulative_property(self):
+        atoms_list = [
+            _make_atoms([[0, 0, 0]]),
+            _make_atoms([[3, 4, 0]]),  # distance = 5
+            _make_atoms([[6, 8, 0]]),  # another 5
+        ]
+        dists = compute_cumulative_distance(atoms_list)
+        np.testing.assert_array_almost_equal(dists, [0.0, 5.0, 10.0])
+
+    def test_monotonically_increasing(self):
+        rng = np.random.default_rng(42)
+        atoms_list = [_make_atoms(rng.random((3, 3))) for _ in range(10)]
+        dists = compute_cumulative_distance(atoms_list)
+        assert all(dists[i] <= dists[i + 1] for i in range(len(dists) - 1))
+
+
+class TestComputeTangentForce:
+    def test_endpoints_are_zero(self):
+        atoms_list = [
+            _make_atoms([[0, 0, 0]], energy=0.0, forces=[[1, 0, 0]]),
+            _make_atoms([[1, 0, 0]], energy=1.0, forces=[[0, 1, 0]]),
+            _make_atoms([[2, 0, 0]], energy=0.5, forces=[[-1, 0, 0]]),
+        ]
+        energies = np.array([0.0, 1.0, 0.5])
+        f_para = compute_tangent_force(atoms_list, energies)
+        assert f_para[0] == 0.0
+        assert f_para[-1] == 0.0
+
+    def test_monotonic_uphill_uses_tau_plus(self):
+        """When e_next > e_curr > e_prev, tangent = tau_plus."""
+        # Linear path along x: 0 -> 1 -> 2
+        # Energies increasing: 0, 1, 2
+        # Force at image 1: [1, 0, 0] (along path)
+        atoms_list = [
+            _make_atoms([[0, 0, 0]], energy=0.0, forces=[[0, 0, 0]]),
+            _make_atoms([[1, 0, 0]], energy=1.0, forces=[[1, 0, 0]]),
+            _make_atoms([[2, 0, 0]], energy=2.0, forces=[[0, 0, 0]]),
+        ]
+        energies = np.array([0.0, 1.0, 2.0])
+        f_para = compute_tangent_force(atoms_list, energies)
+        # tau_plus = [2,0,0]-[1,0,0] = [1,0,0], normalized = [1,0,0]
+        # f_para[1] = dot([1,0,0], [1,0,0]) = 1.0
+        assert f_para[1] == pytest.approx(1.0)
+
+    def test_monotonic_downhill_uses_tau_minus(self):
+        """When e_next < e_curr < e_prev, tangent = tau_minus."""
+        atoms_list = [
+            _make_atoms([[0, 0, 0]], energy=2.0, forces=[[0, 0, 0]]),
+            _make_atoms([[1, 0, 0]], energy=1.0, forces=[[1, 0, 0]]),
+            _make_atoms([[2, 0, 0]], energy=0.0, forces=[[0, 0, 0]]),
+        ]
+        energies = np.array([2.0, 1.0, 0.0])
+        f_para = compute_tangent_force(atoms_list, energies)
+        # tau_minus = [1,0,0]-[0,0,0] = [1,0,0], normalized = [1,0,0]
+        # f_para[1] = dot([1,0,0], [1,0,0]) = 1.0
+        assert f_para[1] == pytest.approx(1.0)
+
+    def test_extremum_uses_bisection(self):
+        """At a maximum, energy-weighted bisection is used."""
+        # Image 1 is at a maximum: e_prev=0, e_curr=2, e_next=1
+        atoms_list = [
+            _make_atoms([[0, 0, 0]], energy=0.0, forces=[[0, 0, 0]]),
+            _make_atoms([[1, 0, 0]], energy=2.0, forces=[[0.5, 0, 0]]),
+            _make_atoms([[2, 0, 0]], energy=1.0, forces=[[0, 0, 0]]),
+        ]
+        energies = np.array([0.0, 2.0, 1.0])
+        f_para = compute_tangent_force(atoms_list, energies)
+        # Not monotonic: extremum case
+        # de_plus = 1-2 = -1, de_minus = 2-0 = 2
+        # de_max = 2, de_min = 1
+        # e_next(1) > e_prev(0), so tau = tau_plus*de_max + tau_minus*de_min
+        # tau_plus = [1,0,0], tau_minus = [1,0,0]
+        # tau = [3, 0, 0], normalized = [1, 0, 0]
+        # f_para[1] = dot([0.5, 0, 0], [1, 0, 0]) = 0.5
+        assert f_para[1] == pytest.approx(0.5)
+
+    def test_no_calc_uses_zero_forces(self):
+        atoms_list = [
+            _make_atoms([[0, 0, 0]], energy=0.0),
+            _make_atoms([[1, 0, 0]], energy=1.0),
+            _make_atoms([[2, 0, 0]], energy=0.5),
+        ]
+        energies = np.array([0.0, 1.0, 0.5])
+        f_para = compute_tangent_force(atoms_list, energies)
+        np.testing.assert_array_equal(f_para, np.zeros(3))
+
+    def test_output_length(self):
+        n = 6
+        atoms_list = [
+            _make_atoms(
+                [[i, 0, 0]], energy=float(i), forces=[[0.1, 0, 0]]
+            )
+            for i in range(n)
+        ]
+        energies = np.arange(n, dtype=float)
+        f_para = compute_tangent_force(atoms_list, energies)
+        assert len(f_para) == n
+
+
+class TestExtractProfileData:
+    def test_returns_four_arrays(self):
+        atoms_list = [
+            _make_atoms([[0, 0, 0]], energy=0.0),
+            _make_atoms([[1, 0, 0]], energy=1.0),
+            _make_atoms([[2, 0, 0]], energy=0.5),
+        ]
+        result = extract_profile_data(atoms_list)
+        assert len(result) == 4
+        indices, distances, energies, f_para = result
+        assert len(indices) == 3
+        assert len(distances) == 3
+        assert len(energies) == 3
+        assert len(f_para) == 3
+
+    def test_indices_are_sequential(self):
+        atoms_list = [_make_atoms([[i, 0, 0]], energy=0.0) for i in range(5)]
+        indices, _, _, _ = extract_profile_data(atoms_list)
+        np.testing.assert_array_equal(indices, [0, 1, 2, 3, 4])
+
+    def test_energies_match(self):
+        expected = [0.0, -1.5, 0.3]
+        atoms_list = [
+            _make_atoms([[i, 0, 0]], energy=e)
+            for i, e in enumerate(expected)
+        ]
+        _, _, energies, _ = extract_profile_data(atoms_list)
+        np.testing.assert_array_almost_equal(energies, expected)
+
+
+class TestTrajectoryToProfileDat:
+    def test_shape_is_5_by_n(self):
+        n = 4
+        atoms_list = [
+            _make_atoms([[i, 0, 0]], energy=float(i)) for i in range(n)
+        ]
+        data = trajectory_to_profile_dat(atoms_list)
+        assert data.shape == (5, n)
+
+    def test_last_row_is_zeros(self):
+        atoms_list = [
+            _make_atoms([[i, 0, 0]], energy=float(i)) for i in range(3)
+        ]
+        data = trajectory_to_profile_dat(atoms_list)
+        np.testing.assert_array_equal(data[4], np.zeros(3))
+
+    def test_index_row_is_sequential(self):
+        atoms_list = [
+            _make_atoms([[i, 0, 0]], energy=float(i)) for i in range(5)
+        ]
+        data = trajectory_to_profile_dat(atoms_list)
+        np.testing.assert_array_equal(data[0], [0, 1, 2, 3, 4])
+
+
+class TestLoadTrajectory:
+    def test_single_atoms_wrapped_in_list(self):
+        single_atoms = Atoms("H", positions=[[0, 0, 0]])
+        with patch(
+            "chemparseplot.parse.trajectory.neb.ase_read",
+            return_value=single_atoms,
+        ):
+            result = load_trajectory("dummy.xyz")
+            assert isinstance(result, list)
+            assert len(result) == 1
+
+    def test_list_returned_as_is(self):
+        atoms_list = [
+            Atoms("H", positions=[[i, 0, 0]]) for i in range(3)
+        ]
+        with patch(
+            "chemparseplot.parse.trajectory.neb.ase_read",
+            return_value=atoms_list,
+        ):
+            result = load_trajectory("dummy.xyz")
+            assert len(result) == 3

--- a/tests/parse/test_trajectory_neb.py
+++ b/tests/parse/test_trajectory_neb.py
@@ -6,7 +6,8 @@
 The physics computations (cumulative distance, tangent forces) are validated
 against hand-calculated reference values.
 """
-from unittest.mock import MagicMock, patch
+
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -37,7 +38,7 @@ def _make_atoms(positions, energy=0.0, forces=None):
     """
     atoms = Atoms("H" * len(positions), positions=positions)
     if forces is not None:
-        from ase.calculators.singlepoint import SinglePointCalculator
+        from ase.calculators.singlepoint import SinglePointCalculator  # noqa: PLC0415
 
         calc = SinglePointCalculator(atoms, energy=energy, forces=forces)
         atoms.calc = calc
@@ -52,9 +53,7 @@ class TestGetEnergy:
         assert _get_energy(atoms) == -1.5
 
     def test_energy_from_calc(self):
-        atoms = _make_atoms(
-            [[0, 0, 0]], energy=-2.0, forces=[[0, 0, 0]]
-        )
+        atoms = _make_atoms([[0, 0, 0]], energy=-2.0, forces=[[0, 0, 0]])
         assert _get_energy(atoms) == -2.0
 
     def test_energy_fallback_zero(self):
@@ -168,9 +167,7 @@ class TestComputeTangentForce:
     def test_output_length(self):
         n = 6
         atoms_list = [
-            _make_atoms(
-                [[i, 0, 0]], energy=float(i), forces=[[0.1, 0, 0]]
-            )
+            _make_atoms([[i, 0, 0]], energy=float(i), forces=[[0.1, 0, 0]])
             for i in range(n)
         ]
         energies = np.arange(n, dtype=float)
@@ -200,10 +197,7 @@ class TestExtractProfileData:
 
     def test_energies_match(self):
         expected = [0.0, -1.5, 0.3]
-        atoms_list = [
-            _make_atoms([[i, 0, 0]], energy=e)
-            for i, e in enumerate(expected)
-        ]
+        atoms_list = [_make_atoms([[i, 0, 0]], energy=e) for i, e in enumerate(expected)]
         _, _, energies, _ = extract_profile_data(atoms_list)
         np.testing.assert_array_almost_equal(energies, expected)
 
@@ -211,23 +205,17 @@ class TestExtractProfileData:
 class TestTrajectoryToProfileDat:
     def test_shape_is_5_by_n(self):
         n = 4
-        atoms_list = [
-            _make_atoms([[i, 0, 0]], energy=float(i)) for i in range(n)
-        ]
+        atoms_list = [_make_atoms([[i, 0, 0]], energy=float(i)) for i in range(n)]
         data = trajectory_to_profile_dat(atoms_list)
         assert data.shape == (5, n)
 
     def test_last_row_is_zeros(self):
-        atoms_list = [
-            _make_atoms([[i, 0, 0]], energy=float(i)) for i in range(3)
-        ]
+        atoms_list = [_make_atoms([[i, 0, 0]], energy=float(i)) for i in range(3)]
         data = trajectory_to_profile_dat(atoms_list)
         np.testing.assert_array_equal(data[4], np.zeros(3))
 
     def test_index_row_is_sequential(self):
-        atoms_list = [
-            _make_atoms([[i, 0, 0]], energy=float(i)) for i in range(5)
-        ]
+        atoms_list = [_make_atoms([[i, 0, 0]], energy=float(i)) for i in range(5)]
         data = trajectory_to_profile_dat(atoms_list)
         np.testing.assert_array_equal(data[0], [0, 1, 2, 3, 4])
 
@@ -244,9 +232,7 @@ class TestLoadTrajectory:
             assert len(result) == 1
 
     def test_list_returned_as_is(self):
-        atoms_list = [
-            Atoms("H", positions=[[i, 0, 0]]) for i in range(3)
-        ]
+        atoms_list = [Atoms("H", positions=[[i, 0, 0]]) for i in range(3)]
         with patch(
             "chemparseplot.parse.trajectory.neb.ase_read",
             return_value=atoms_list,

--- a/tests/plot/test_neb_renderers.py
+++ b/tests/plot/test_neb_renderers.py
@@ -67,7 +67,7 @@ class TestRenderXyzrender:
         img = _render_xyzrender(water, canvas_size=200)
         assert isinstance(img, np.ndarray)
         assert img.ndim == 3
-        assert img.shape[2] == 4
+        assert img.shape[2] in (3, 4)
 
 
 class TestPlotStructureStripRendererParam:

--- a/tests/plot/test_neb_renderers.py
+++ b/tests/plot/test_neb_renderers.py
@@ -11,6 +11,7 @@ from tests.conftest import skip_if_not_env
 
 skip_if_not_env("neb")
 
+import matplotlib.pyplot as plt  # noqa: E402
 from ase import Atoms  # noqa: E402
 
 from chemparseplot.plot.neb import (  # noqa: E402
@@ -39,7 +40,7 @@ class TestRenderStructureToImage:
         assert isinstance(img, np.ndarray)
         assert img.ndim == 3
         assert img.shape[2] == 4
-        assert img.dtype == np.float32 or img.dtype == np.float64
+        assert img.dtype in (np.float32, np.float64)
 
 
 class TestCheckXyzrender:
@@ -73,19 +74,13 @@ class TestPlotStructureStripRendererParam:
     """Renderer dispatch in plot_structure_strip."""
 
     def test_ase_renderer_called(self, water):
-        import matplotlib.pyplot as plt
-
         _, ax = plt.subplots()
         atoms_list = [water, water]
         labels = ["A", "B"]
 
-        with patch(
-            "chemparseplot.plot.neb.render_structure_to_image"
-        ) as mock_render:
+        with patch("chemparseplot.plot.neb.render_structure_to_image") as mock_render:
             mock_render.return_value = np.zeros((10, 10, 4), dtype=np.float32)
-            plot_structure_strip(
-                ax, atoms_list, labels, renderer="ase"
-            )
+            plot_structure_strip(ax, atoms_list, labels, renderer="ase")
             assert mock_render.call_count == len(atoms_list)
 
         plt.close("all")

--- a/tests/plot/test_neb_renderers.py
+++ b/tests/plot/test_neb_renderers.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2023-present Rohit Goswami <rog32@hi.is>
+#
+# SPDX-License-Identifier: MIT
+import shutil
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from tests.conftest import skip_if_not_env
+
+skip_if_not_env("neb")
+
+from ase import Atoms  # noqa: E402
+
+from chemparseplot.plot.neb import (  # noqa: E402
+    _check_xyzrender,
+    _render_xyzrender,
+    plot_structure_strip,
+    render_structure_to_image,
+)
+
+pytestmark = pytest.mark.neb
+
+
+@pytest.fixture()
+def water():
+    return Atoms(
+        "H2O",
+        positions=[[0, 0, 0], [0.76, 0.59, 0], [-0.76, 0.59, 0]],
+    )
+
+
+class TestRenderStructureToImage:
+    """ASE renderer contract."""
+
+    def test_returns_rgba(self, water):
+        img = render_structure_to_image(water, zoom=0.3, rotation="0x,90y,0z")
+        assert isinstance(img, np.ndarray)
+        assert img.ndim == 3
+        assert img.shape[2] == 4
+        assert img.dtype == np.float32 or img.dtype == np.float64
+
+
+class TestCheckXyzrender:
+    """Binary availability check."""
+
+    def test_missing_binary_raises(self):
+        with patch.object(shutil, "which", return_value=None):
+            with pytest.raises(RuntimeError, match="xyzrender binary not found"):
+                _check_xyzrender()
+
+    def test_present_binary_passes(self):
+        with patch.object(shutil, "which", return_value="/usr/bin/xyzrender"):
+            _check_xyzrender()
+
+
+class TestRenderXyzrender:
+    """xyzrender subprocess renderer."""
+
+    @pytest.mark.skipif(
+        shutil.which("xyzrender") is None,
+        reason="xyzrender not installed",
+    )
+    def test_produces_image(self, water):
+        img = _render_xyzrender(water, canvas_size=200)
+        assert isinstance(img, np.ndarray)
+        assert img.ndim == 3
+        assert img.shape[2] == 4
+
+
+class TestPlotStructureStripRendererParam:
+    """Renderer dispatch in plot_structure_strip."""
+
+    def test_ase_renderer_called(self, water):
+        import matplotlib.pyplot as plt
+
+        _, ax = plt.subplots()
+        atoms_list = [water, water]
+        labels = ["A", "B"]
+
+        with patch(
+            "chemparseplot.plot.neb.render_structure_to_image"
+        ) as mock_render:
+            mock_render.return_value = np.zeros((10, 10, 4), dtype=np.float32)
+            plot_structure_strip(
+                ax, atoms_list, labels, renderer="ase"
+            )
+            assert mock_render.call_count == len(atoms_list)
+
+        plt.close("all")

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,22 @@ wheels = [
 ]
 
 [[package]]
+name = "ase"
+version = "3.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/d38b39abd24110deb13bee0dc14404eca1f2113c01bc9bbf075dc3e1c2dd/ase-3.27.0.tar.gz", hash = "sha256:92ada752d6866a61d2d27e0e6a4fd5b8cd86f59ca79a58f1d2fe29d7099153dc", size = 2363050, upload-time = "2025-12-28T15:41:22.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/9b/9b55b4d4855743de61ba91566d03b2560285ed8fc0387b9cf914795d4abf/ase-3.27.0-py3-none-any.whl", hash = "sha256:058c48ea504fe7fbbe7c932f778415243ef2df45b1ab869866f24efcc17f0538", size = 2885170, upload-time = "2025-12-28T15:41:20.257Z" },
+]
+
+[[package]]
 name = "astroid"
 version = "3.3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -274,6 +290,11 @@ doc = [
 lint = [
     { name = "ruff" },
 ]
+neb = [
+    { name = "ase" },
+    { name = "h5py" },
+    { name = "polars" },
+]
 plot = [
     { name = "cmcrameri" },
     { name = "matplotlib" },
@@ -285,13 +306,16 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ase", marker = "extra == 'neb'", specifier = ">=3.22" },
     { name = "cmcrameri", marker = "extra == 'plot'", specifier = ">=1.7" },
+    { name = "h5py", marker = "extra == 'neb'", specifier = ">=3.0" },
     { name = "matplotlib", marker = "extra == 'plot'", specifier = ">=3.8.2" },
     { name = "mdit-py-plugins", marker = "extra == 'doc'", specifier = ">=0.3.4" },
     { name = "myst-nb", marker = "extra == 'doc'", specifier = ">=1" },
     { name = "myst-parser", marker = "extra == 'doc'", specifier = ">=2" },
     { name = "numpy", specifier = ">=1.26.2" },
     { name = "pint", specifier = ">=0.22" },
+    { name = "polars", marker = "extra == 'neb'", specifier = ">=0.20" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.4.3" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
     { name = "rgpycrumbs", git = "https://github.com/HaoZeke/rgpycrumbs" },
@@ -304,7 +328,7 @@ requires-dist = [
     { name = "sphinx-togglebutton", marker = "extra == 'doc'", specifier = ">=0.3.2" },
     { name = "sphinxcontrib-apidoc", marker = "extra == 'doc'", specifier = ">=0.4" },
 ]
-provides-extras = ["doc", "lint", "plot", "test"]
+provides-extras = ["doc", "lint", "neb", "plot", "test"]
 
 [[package]]
 name = "click"
@@ -865,6 +889,57 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
     { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
+]
+
+[[package]]
+name = "h5py"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/6a/0d79de0b025aa85dc8864de8e97659c94cf3d23148394a954dc5ca52f8c8/h5py-3.15.1.tar.gz", hash = "sha256:c86e3ed45c4473564de55aa83b6fc9e5ead86578773dfbd93047380042e26b69", size = 426236, upload-time = "2025-10-16T10:35:27.404Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/30/8fa61698b438dd751fa46a359792e801191dadab560d0a5f1c709443ef8e/h5py-3.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:67e59f6c2f19a32973a40f43d9a088ae324fe228c8366e25ebc57ceebf093a6b", size = 3414477, upload-time = "2025-10-16T10:33:24.201Z" },
+    { url = "https://files.pythonhosted.org/packages/16/16/db2f63302937337c4e9e51d97a5984b769bdb7488e3d37632a6ac297f8ef/h5py-3.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e2f471688402c3404fa4e13466e373e622fd4b74b47b56cfdff7cc688209422", size = 2850298, upload-time = "2025-10-16T10:33:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2e/f1bb7de9b05112bfd14d5206090f0f92f1e75bbb412fbec5d4653c3d44dd/h5py-3.15.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c45802bcb711e128a6839cb6c01e9ac648dc55df045c9542a675c771f15c8d5", size = 4523605, upload-time = "2025-10-16T10:33:31.168Z" },
+    { url = "https://files.pythonhosted.org/packages/05/8a/63f4b08f3628171ce8da1a04681a65ee7ac338fde3cb3e9e3c9f7818e4da/h5py-3.15.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64ce3f6470adb87c06e3a8dd1b90e973699f1759ad79bfa70c230939bff356c9", size = 4735346, upload-time = "2025-10-16T10:33:34.759Z" },
+    { url = "https://files.pythonhosted.org/packages/74/48/f16d12d9de22277605bcc11c0dcab5e35f06a54be4798faa2636b5d44b3c/h5py-3.15.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4411c1867b9899a25e983fff56d820a66f52ac326bbe10c7cdf7d832c9dcd883", size = 4175305, upload-time = "2025-10-16T10:33:38.83Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/47cdbff65b2ce53c27458c6df63a232d7bb1644b97df37b2342442342c84/h5py-3.15.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2cbc4104d3d4aca9d6db8c0c694555e255805bfeacf9eb1349bda871e26cacbe", size = 4653602, upload-time = "2025-10-16T10:33:42.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/28/dc08de359c2f43a67baa529cb70d7f9599848750031975eed92d6ae78e1d/h5py-3.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:01f55111ca516f5568ae7a7fc8247dfce607de331b4467ee8a9a6ed14e5422c7", size = 2873601, upload-time = "2025-10-16T10:33:45.323Z" },
+    { url = "https://files.pythonhosted.org/packages/41/fd/8349b48b15b47768042cff06ad6e1c229f0a4bd89225bf6b6894fea27e6d/h5py-3.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5aaa330bcbf2830150c50897ea5dcbed30b5b6d56897289846ac5b9e529ec243", size = 3434135, upload-time = "2025-10-16T10:33:47.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b0/1c628e26a0b95858f54aba17e1599e7f6cd241727596cc2580b72cb0a9bf/h5py-3.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c970fb80001fffabb0109eaf95116c8e7c0d3ca2de854e0901e8a04c1f098509", size = 2870958, upload-time = "2025-10-16T10:33:50.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e3/c255cafc9b85e6ea04e2ad1bba1416baa1d7f57fc98a214be1144087690c/h5py-3.15.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:80e5bb5b9508d5d9da09f81fd00abbb3f85da8143e56b1585d59bc8ceb1dba8b", size = 4504770, upload-time = "2025-10-16T10:33:54.357Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/23/4ab1108e87851ccc69694b03b817d92e142966a6c4abd99e17db77f2c066/h5py-3.15.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5b849ba619a066196169763c33f9f0f02e381156d61c03e000bb0100f9950faf", size = 4700329, upload-time = "2025-10-16T10:33:57.616Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e4/932a3a8516e4e475b90969bf250b1924dbe3612a02b897e426613aed68f4/h5py-3.15.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e7f6c841efd4e6e5b7e82222eaf90819927b6d256ab0f3aca29675601f654f3c", size = 4152456, upload-time = "2025-10-16T10:34:00.843Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0a/f74d589883b13737021b2049ac796328f188dbb60c2ed35b101f5b95a3fc/h5py-3.15.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ca8a3a22458956ee7b40d8e39c9a9dc01f82933e4c030c964f8b875592f4d831", size = 4617295, upload-time = "2025-10-16T10:34:04.154Z" },
+    { url = "https://files.pythonhosted.org/packages/23/95/499b4e56452ef8b6c95a271af0dde08dac4ddb70515a75f346d4f400579b/h5py-3.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:550e51131376889656feec4aff2170efc054a7fe79eb1da3bb92e1625d1ac878", size = 2882129, upload-time = "2025-10-16T10:34:06.886Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bb/cfcc70b8a42222ba3ad4478bcef1791181ea908e2adbd7d53c66395edad5/h5py-3.15.1-cp311-cp311-win_arm64.whl", hash = "sha256:b39239947cb36a819147fc19e86b618dcb0953d1cd969f5ed71fc0de60392427", size = 2477121, upload-time = "2025-10-16T10:34:09.579Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b8/c0d9aa013ecfa8b7057946c080c0c07f6fa41e231d2e9bd306a2f8110bdc/h5py-3.15.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:316dd0f119734f324ca7ed10b5627a2de4ea42cc4dfbcedbee026aaa361c238c", size = 3399089, upload-time = "2025-10-16T10:34:12.135Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5e/3c6f6e0430813c7aefe784d00c6711166f46225f5d229546eb53032c3707/h5py-3.15.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b51469890e58e85d5242e43aab29f5e9c7e526b951caab354f3ded4ac88e7b76", size = 2847803, upload-time = "2025-10-16T10:34:14.564Z" },
+    { url = "https://files.pythonhosted.org/packages/00/69/ba36273b888a4a48d78f9268d2aee05787e4438557450a8442946ab8f3ec/h5py-3.15.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a33bfd5dfcea037196f7778534b1ff7e36a7f40a89e648c8f2967292eb6898e", size = 4914884, upload-time = "2025-10-16T10:34:18.452Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/30/d1c94066343a98bb2cea40120873193a4fed68c4ad7f8935c11caf74c681/h5py-3.15.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25c8843fec43b2cc368aa15afa1cdf83fc5e17b1c4e10cd3771ef6c39b72e5ce", size = 5109965, upload-time = "2025-10-16T10:34:21.853Z" },
+    { url = "https://files.pythonhosted.org/packages/81/3d/d28172116eafc3bc9f5991b3cb3fd2c8a95f5984f50880adfdf991de9087/h5py-3.15.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a308fd8681a864c04423c0324527237a0484e2611e3441f8089fd00ed56a8171", size = 4561870, upload-time = "2025-10-16T10:34:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/393a7226024238b0f51965a7156004eaae1fcf84aa4bfecf7e582676271b/h5py-3.15.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f4a016df3f4a8a14d573b496e4d1964deb380e26031fc85fb40e417e9131888a", size = 5037161, upload-time = "2025-10-16T10:34:30.383Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/51/329e7436bf87ca6b0fe06dd0a3795c34bebe4ed8d6c44450a20565d57832/h5py-3.15.1-cp312-cp312-win_amd64.whl", hash = "sha256:59b25cf02411bf12e14f803fef0b80886444c7fe21a5ad17c6a28d3f08098a1e", size = 2874165, upload-time = "2025-10-16T10:34:33.461Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/2d02b10a66747c54446e932171dd89b8b4126c0111b440e6bc05a7c852ec/h5py-3.15.1-cp312-cp312-win_arm64.whl", hash = "sha256:61d5a58a9851e01ee61c932bbbb1c98fe20aba0a5674776600fb9a361c0aa652", size = 2458214, upload-time = "2025-10-16T10:34:35.733Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/40207e0192415cbff7ea1d37b9f24b33f6d38a5a2f5d18a678de78f967ae/h5py-3.15.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c8440fd8bee9500c235ecb7aa1917a0389a2adb80c209fa1cc485bd70e0d94a5", size = 3376511, upload-time = "2025-10-16T10:34:38.596Z" },
+    { url = "https://files.pythonhosted.org/packages/31/96/ba99a003c763998035b0de4c299598125df5fc6c9ccf834f152ddd60e0fb/h5py-3.15.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ab2219dbc6fcdb6932f76b548e2b16f34a1f52b7666e998157a4dfc02e2c4123", size = 2826143, upload-time = "2025-10-16T10:34:41.342Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c2/fc6375d07ea3962df7afad7d863fe4bde18bb88530678c20d4c90c18de1d/h5py-3.15.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8cb02c3a96255149ed3ac811eeea25b655d959c6dd5ce702c9a95ff11859eb5", size = 4908316, upload-time = "2025-10-16T10:34:44.619Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/69/4402ea66272dacc10b298cca18ed73e1c0791ff2ae9ed218d3859f9698ac/h5py-3.15.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:121b2b7a4c1915d63737483b7bff14ef253020f617c2fb2811f67a4bed9ac5e8", size = 5103710, upload-time = "2025-10-16T10:34:48.639Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f6/11f1e2432d57d71322c02a97a5567829a75f223a8c821764a0e71a65cde8/h5py-3.15.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:59b0d63b318bf3cc06687def2b45afd75926bbc006f7b8cd2b1a231299fc8599", size = 4556042, upload-time = "2025-10-16T10:34:51.841Z" },
+    { url = "https://files.pythonhosted.org/packages/18/88/3eda3ef16bfe7a7dbc3d8d6836bbaa7986feb5ff091395e140dc13927bcc/h5py-3.15.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e02fe77a03f652500d8bff288cbf3675f742fc0411f5a628fa37116507dc7cc0", size = 5030639, upload-time = "2025-10-16T10:34:55.257Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ea/fbb258a98863f99befb10ed727152b4ae659f322e1d9c0576f8a62754e81/h5py-3.15.1-cp313-cp313-win_amd64.whl", hash = "sha256:dea78b092fd80a083563ed79a3171258d4a4d307492e7cf8b2313d464c82ba52", size = 2864363, upload-time = "2025-10-16T10:34:58.099Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/c9/35021cc9cd2b2915a7da3026e3d77a05bed1144a414ff840953b33937fb9/h5py-3.15.1-cp313-cp313-win_arm64.whl", hash = "sha256:c256254a8a81e2bddc0d376e23e2a6d2dc8a1e8a2261835ed8c1281a0744cd97", size = 2449570, upload-time = "2025-10-16T10:35:00.473Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2c/926eba1514e4d2e47d0e9eb16c784e717d8b066398ccfca9b283917b1bfb/h5py-3.15.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5f4fb0567eb8517c3ecd6b3c02c4f4e9da220c8932604960fd04e24ee1254763", size = 3380368, upload-time = "2025-10-16T10:35:03.117Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4b/d715ed454d3baa5f6ae1d30b7eca4c7a1c1084f6a2edead9e801a1541d62/h5py-3.15.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:954e480433e82d3872503104f9b285d369048c3a788b2b1a00e53d1c47c98dd2", size = 2833793, upload-time = "2025-10-16T10:35:05.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d4/ef386c28e4579314610a8bffebbee3b69295b0237bc967340b7c653c6c10/h5py-3.15.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd125c131889ebbef0849f4a0e29cf363b48aba42f228d08b4079913b576bb3a", size = 4903199, upload-time = "2025-10-16T10:35:08.972Z" },
+    { url = "https://files.pythonhosted.org/packages/33/5d/65c619e195e0b5e54ea5a95c1bb600c8ff8715e0d09676e4cce56d89f492/h5py-3.15.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28a20e1a4082a479b3d7db2169f3a5034af010b90842e75ebbf2e9e49eb4183e", size = 5097224, upload-time = "2025-10-16T10:35:12.808Z" },
+    { url = "https://files.pythonhosted.org/packages/30/30/5273218400bf2da01609e1292f562c94b461fcb73c7a9e27fdadd43abc0a/h5py-3.15.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa8df5267f545b4946df8ca0d93d23382191018e4cda2deda4c2cedf9a010e13", size = 4551207, upload-time = "2025-10-16T10:35:16.24Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/39/a7ef948ddf4d1c556b0b2b9559534777bccc318543b3f5a1efdf6b556c9c/h5py-3.15.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99d374a21f7321a4c6ab327c4ab23bd925ad69821aeb53a1e75dd809d19f67fa", size = 5025426, upload-time = "2025-10-16T10:35:19.831Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d8/7368679b8df6925b8415f9dcc9ab1dab01ddc384d2b2c24aac9191bd9ceb/h5py-3.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:9c73d1d7cdb97d5b17ae385153472ce118bed607e43be11e9a9deefaa54e0734", size = 2865704, upload-time = "2025-10-16T10:35:22.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/4a806f85d62c20157e62e58e03b27513dc9c55499768530acc4f4c5ce4be/h5py-3.15.1-cp314-cp314-win_arm64.whl", hash = "sha256:a6d8c5a05a76aca9a494b4c53ce8a9c29023b7f64f625c6ce1841e92a362ccdf", size = 2465544, upload-time = "2025-10-16T10:35:25.695Z" },
 ]
 
 [[package]]
@@ -1875,6 +1950,34 @@ wheels = [
 ]
 
 [[package]]
+name = "polars"
+version = "1.38.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/5e/208a24471a433bcd0e9a6889ac49025fd4daad2815c8220c5bd2576e5f1b/polars-1.38.1.tar.gz", hash = "sha256:803a2be5344ef880ad625addfb8f641995cfd777413b08a10de0897345778239", size = 717667, upload-time = "2026-02-06T18:13:23.013Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/737c1a6273c585719858261753da0b688454d1b634438ccba8a9c4eb5aab/polars-1.38.1-py3-none-any.whl", hash = "sha256:a29479c48fed4984d88b656486d221f638cba45d3e961631a50ee5fdde38cb2c", size = 810368, upload-time = "2026-02-06T18:11:55.819Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.38.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/4b/04d6b3fb7cf336fbe12fbc4b43f36d1783e11bb0f2b1e3980ec44878df06/polars_runtime_32-1.38.1.tar.gz", hash = "sha256:04f20ed1f5c58771f34296a27029dc755a9e4b1390caeaef8f317e06fdfce2ec", size = 2812631, upload-time = "2026-02-06T18:13:25.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a2/a00defbddadd8cf1042f52380dcba6b6592b03bac8e3b34c436b62d12d3b/polars_runtime_32-1.38.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:18154e96044724a0ac38ce155cf63aa03c02dd70500efbbf1a61b08cadd269ef", size = 44108001, upload-time = "2026-02-06T18:11:58.127Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/fb/599ff3709e6a303024efd7edfd08cf8de55c6ac39527d8f41cbc4399385f/polars_runtime_32-1.38.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c49acac34cc4049ed188f1eb67d6ff3971a39b4af7f7b734b367119970f313ac", size = 40230140, upload-time = "2026-02-06T18:12:01.181Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8c/3ac18d6f89dc05fe2c7c0ee1dc5b81f77a5c85ad59898232c2500fe2ebbf/polars_runtime_32-1.38.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fef2ef2626a954e010e006cc8e4de467ecf32d08008f130cea1c78911f545323", size = 41994039, upload-time = "2026-02-06T18:12:04.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/5a/61d60ec5cc0ab37cbd5a699edb2f9af2875b7fdfdfb2a4608ca3cc5f0448/polars_runtime_32-1.38.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8a5f7a8125e2d50e2e060296551c929aec09be23a9edcb2b12ca923f555a5ba", size = 45755804, upload-time = "2026-02-06T18:12:07.846Z" },
+    { url = "https://files.pythonhosted.org/packages/91/54/02cd4074c98c361ccd3fec3bcb0bd68dbc639c0550c42a4436b0ff0f3ccf/polars_runtime_32-1.38.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:10d19cd9863e129273b18b7fcaab625b5c8143c2d22b3e549067b78efa32e4fa", size = 42159605, upload-time = "2026-02-06T18:12:10.919Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f3/b2a5e720cc56eaa38b4518e63aa577b4bbd60e8b05a00fe43ca051be5879/polars_runtime_32-1.38.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61e8d73c614b46a00d2f853625a7569a2e4a0999333e876354ac81d1bf1bb5e2", size = 45336615, upload-time = "2026-02-06T18:12:14.074Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/8d/ee2e4b7de948090cfb3df37d401c521233daf97bfc54ddec5d61d1d31618/polars_runtime_32-1.38.1-cp310-abi3-win_amd64.whl", hash = "sha256:08c2b3b93509c1141ac97891294ff5c5b0c548a373f583eaaea873a4bf506437", size = 45680732, upload-time = "2026-02-06T18:12:19.097Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/18/72c216f4ab0c82b907009668f79183ae029116ff0dd245d56ef58aac48e7/polars_runtime_32-1.38.1-cp310-abi3-win_arm64.whl", hash = "sha256:6d07d0cc832bfe4fb54b6e04218c2c27afcfa6b9498f9f6bbf262a00d58cc7c4", size = 41639413, upload-time = "2026-02-06T18:12:22.044Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -2348,6 +2451,140 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/01/1c30526460f4d23222d0fabd5888868262fd0e2b71a00570ca26483cd993/ruff-0.15.2-py3-none-win32.whl", hash = "sha256:fd5ff9e5f519a7e1bd99cbe8daa324010a74f5e2ebc97c6242c08f26f3714f6f", size = 10507885, upload-time = "2026-02-19T22:32:15.635Z" },
     { url = "https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl", hash = "sha256:d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5", size = 11623725, upload-time = "2026-02-19T22:32:04.947Z" },
     { url = "https://files.pythonhosted.org/packages/6d/78/097c0798b1dab9f8affe73da9642bb4500e098cb27fd8dc9724816ac747b/ruff-0.15.2-py3-none-win_arm64.whl", hash = "sha256:cabddc5822acdc8f7b5527b36ceac55cc51eec7b1946e60181de8fe83ca8876e", size = 10941649, upload-time = "2026-02-19T22:32:18.108Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.15.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/2f/4966032c5f8cc7e6a60f1b2e0ad686293b9474b65246b0c642e3ef3badd0/scipy-1.15.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:a345928c86d535060c9c2b25e71e87c39ab2f22fc96e9636bd74d1dbf9de448c", size = 38702770, upload-time = "2025-05-08T16:04:20.849Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/6e/0c3bf90fae0e910c274db43304ebe25a6b391327f3f10b5dcc638c090795/scipy-1.15.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:ad3432cb0f9ed87477a8d97f03b763fd1d57709f1bbde3c9369b1dff5503b253", size = 30094511, upload-time = "2025-05-08T16:04:27.103Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b1/4deb37252311c1acff7f101f6453f0440794f51b6eacb1aad4459a134081/scipy-1.15.3-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:aef683a9ae6eb00728a542b796f52a5477b78252edede72b8327a886ab63293f", size = 22368151, upload-time = "2025-05-08T16:04:31.731Z" },
+    { url = "https://files.pythonhosted.org/packages/38/7d/f457626e3cd3c29b3a49ca115a304cebb8cc6f31b04678f03b216899d3c6/scipy-1.15.3-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:1c832e1bd78dea67d5c16f786681b28dd695a8cb1fb90af2e27580d3d0967e92", size = 25121732, upload-time = "2025-05-08T16:04:36.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/0a/92b1de4a7adc7a15dcf5bddc6e191f6f29ee663b30511ce20467ef9b82e4/scipy-1.15.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:263961f658ce2165bbd7b99fa5135195c3a12d9bef045345016b8b50c315cb82", size = 35547617, upload-time = "2025-05-08T16:04:43.546Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/6d/41991e503e51fc1134502694c5fa7a1671501a17ffa12716a4a9151af3df/scipy-1.15.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e2abc762b0811e09a0d3258abee2d98e0c703eee49464ce0069590846f31d40", size = 37662964, upload-time = "2025-05-08T16:04:49.431Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e1/3df8f83cb15f3500478c889be8fb18700813b95e9e087328230b98d547ff/scipy-1.15.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ed7284b21a7a0c8f1b6e5977ac05396c0d008b89e05498c8b7e8f4a1423bba0e", size = 37238749, upload-time = "2025-05-08T16:04:55.215Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/b3257cf446f2a3533ed7809757039016b74cd6f38271de91682aa844cfc5/scipy-1.15.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5380741e53df2c566f4d234b100a484b420af85deb39ea35a1cc1be84ff53a5c", size = 40022383, upload-time = "2025-05-08T16:05:01.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/55bc4881973d3f79b479a5a2e2df61c8c9a04fcb986a213ac9c02cfb659b/scipy-1.15.3-cp310-cp310-win_amd64.whl", hash = "sha256:9d61e97b186a57350f6d6fd72640f9e99d5a4a2b8fbf4b9ee9a841eab327dc13", size = 41259201, upload-time = "2025-05-08T16:05:08.166Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ab/5cc9f80f28f6a7dff646c5756e559823614a42b1939d86dd0ed550470210/scipy-1.15.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:993439ce220d25e3696d1b23b233dd010169b62f6456488567e830654ee37a6b", size = 38714255, upload-time = "2025-05-08T16:05:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4a/66ba30abe5ad1a3ad15bfb0b59d22174012e8056ff448cb1644deccbfed2/scipy-1.15.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:34716e281f181a02341ddeaad584205bd2fd3c242063bd3423d61ac259ca7eba", size = 30111035, upload-time = "2025-05-08T16:05:20.152Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/a7e5b95afd80d24313307f03624acc65801846fa75599034f8ceb9e2cbf6/scipy-1.15.3-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3b0334816afb8b91dab859281b1b9786934392aa3d527cd847e41bb6f45bee65", size = 22384499, upload-time = "2025-05-08T16:05:24.494Z" },
+    { url = "https://files.pythonhosted.org/packages/17/99/f3aaddccf3588bb4aea70ba35328c204cadd89517a1612ecfda5b2dd9d7a/scipy-1.15.3-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:6db907c7368e3092e24919b5e31c76998b0ce1684d51a90943cb0ed1b4ffd6c1", size = 25152602, upload-time = "2025-05-08T16:05:29.313Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c5/1032cdb565f146109212153339f9cb8b993701e9fe56b1c97699eee12586/scipy-1.15.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:721d6b4ef5dc82ca8968c25b111e307083d7ca9091bc38163fb89243e85e3889", size = 35503415, upload-time = "2025-05-08T16:05:34.699Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/37/89f19c8c05505d0601ed5650156e50eb881ae3918786c8fd7262b4ee66d3/scipy-1.15.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39cb9c62e471b1bb3750066ecc3a3f3052b37751c7c3dfd0fd7e48900ed52982", size = 37652622, upload-time = "2025-05-08T16:05:40.762Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/31/be59513aa9695519b18e1851bb9e487de66f2d31f835201f1b42f5d4d475/scipy-1.15.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:795c46999bae845966368a3c013e0e00947932d68e235702b5c3f6ea799aa8c9", size = 37244796, upload-time = "2025-05-08T16:05:48.119Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c0/4f5f3eeccc235632aab79b27a74a9130c6c35df358129f7ac8b29f562ac7/scipy-1.15.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:18aaacb735ab38b38db42cb01f6b92a2d0d4b6aabefeb07f02849e47f8fb3594", size = 40047684, upload-time = "2025-05-08T16:05:54.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a7/0ddaf514ce8a8714f6ed243a2b391b41dbb65251affe21ee3077ec45ea9a/scipy-1.15.3-cp311-cp311-win_amd64.whl", hash = "sha256:ae48a786a28412d744c62fd7816a4118ef97e5be0bee968ce8f0a2fba7acf3bb", size = 41246504, upload-time = "2025-05-08T16:06:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/683aa044c4162e10ed7a7ea30527f2cbd92e6999c10a8ed8edb253836e9c/scipy-1.15.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6ac6310fdbfb7aa6612408bd2f07295bcbd3fda00d2d702178434751fe48e019", size = 38766735, upload-time = "2025-05-08T16:06:06.471Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/f30be3d03de07f25dc0ec926d1681fed5c732d759ac8f51079708c79e680/scipy-1.15.3-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:185cd3d6d05ca4b44a8f1595af87f9c372bb6acf9c808e99aa3e9aa03bd98cf6", size = 30173284, upload-time = "2025-05-08T16:06:11.686Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9c/0ddb0d0abdabe0d181c1793db51f02cd59e4901da6f9f7848e1f96759f0d/scipy-1.15.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:05dc6abcd105e1a29f95eada46d4a3f251743cfd7d3ae8ddb4088047f24ea477", size = 22446958, upload-time = "2025-05-08T16:06:15.97Z" },
+    { url = "https://files.pythonhosted.org/packages/af/43/0bce905a965f36c58ff80d8bea33f1f9351b05fad4beaad4eae34699b7a1/scipy-1.15.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:06efcba926324df1696931a57a176c80848ccd67ce6ad020c810736bfd58eb1c", size = 25242454, upload-time = "2025-05-08T16:06:20.394Z" },
+    { url = "https://files.pythonhosted.org/packages/56/30/a6f08f84ee5b7b28b4c597aca4cbe545535c39fe911845a96414700b64ba/scipy-1.15.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c05045d8b9bfd807ee1b9f38761993297b10b245f012b11b13b91ba8945f7e45", size = 35210199, upload-time = "2025-05-08T16:06:26.159Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1f/03f52c282437a168ee2c7c14a1a0d0781a9a4a8962d84ac05c06b4c5b555/scipy-1.15.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:271e3713e645149ea5ea3e97b57fdab61ce61333f97cfae392c28ba786f9bb49", size = 37309455, upload-time = "2025-05-08T16:06:32.778Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b1/fbb53137f42c4bf630b1ffdfc2151a62d1d1b903b249f030d2b1c0280af8/scipy-1.15.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6cfd56fc1a8e53f6e89ba3a7a7251f7396412d655bca2aa5611c8ec9a6784a1e", size = 36885140, upload-time = "2025-05-08T16:06:39.249Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2e/025e39e339f5090df1ff266d021892694dbb7e63568edcfe43f892fa381d/scipy-1.15.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ff17c0bb1cb32952c09217d8d1eed9b53d1463e5f1dd6052c7857f83127d539", size = 39710549, upload-time = "2025-05-08T16:06:45.729Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/eb/3bf6ea8ab7f1503dca3a10df2e4b9c3f6b3316df07f6c0ded94b281c7101/scipy-1.15.3-cp312-cp312-win_amd64.whl", hash = "sha256:52092bc0472cfd17df49ff17e70624345efece4e1a12b23783a1ac59a1b728ed", size = 40966184, upload-time = "2025-05-08T16:06:52.623Z" },
+    { url = "https://files.pythonhosted.org/packages/73/18/ec27848c9baae6e0d6573eda6e01a602e5649ee72c27c3a8aad673ebecfd/scipy-1.15.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2c620736bcc334782e24d173c0fdbb7590a0a436d2fdf39310a8902505008759", size = 38728256, upload-time = "2025-05-08T16:06:58.696Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/1aef2184948728b4b6e21267d53b3339762c285a46a274ebb7863c9e4742/scipy-1.15.3-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:7e11270a000969409d37ed399585ee530b9ef6aa99d50c019de4cb01e8e54e62", size = 30109540, upload-time = "2025-05-08T16:07:04.209Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/d8/59e452c0a255ec352bd0a833537a3bc1bfb679944c4938ab375b0a6b3a3e/scipy-1.15.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:8c9ed3ba2c8a2ce098163a9bdb26f891746d02136995df25227a20e71c396ebb", size = 22383115, upload-time = "2025-05-08T16:07:08.998Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/456f56bbbfccf696263b47095291040655e3cbaf05d063bdc7c7517f32ac/scipy-1.15.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:0bdd905264c0c9cfa74a4772cdb2070171790381a5c4d312c973382fc6eaf730", size = 25163884, upload-time = "2025-05-08T16:07:14.091Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/66/a9618b6a435a0f0c0b8a6d0a2efb32d4ec5a85f023c2b79d39512040355b/scipy-1.15.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79167bba085c31f38603e11a267d862957cbb3ce018d8b38f79ac043bc92d825", size = 35174018, upload-time = "2025-05-08T16:07:19.427Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/09/c5b6734a50ad4882432b6bb7c02baf757f5b2f256041da5df242e2d7e6b6/scipy-1.15.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9deabd6d547aee2c9a81dee6cc96c6d7e9a9b1953f74850c179f91fdc729cb7", size = 37269716, upload-time = "2025-05-08T16:07:25.712Z" },
+    { url = "https://files.pythonhosted.org/packages/77/0a/eac00ff741f23bcabd352731ed9b8995a0a60ef57f5fd788d611d43d69a1/scipy-1.15.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:dde4fc32993071ac0c7dd2d82569e544f0bdaff66269cb475e0f369adad13f11", size = 36872342, upload-time = "2025-05-08T16:07:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/54/4379be86dd74b6ad81551689107360d9a3e18f24d20767a2d5b9253a3f0a/scipy-1.15.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f77f853d584e72e874d87357ad70f44b437331507d1c311457bed8ed2b956126", size = 39670869, upload-time = "2025-05-08T16:07:38.002Z" },
+    { url = "https://files.pythonhosted.org/packages/87/2e/892ad2862ba54f084ffe8cc4a22667eaf9c2bcec6d2bff1d15713c6c0703/scipy-1.15.3-cp313-cp313-win_amd64.whl", hash = "sha256:b90ab29d0c37ec9bf55424c064312930ca5f4bde15ee8619ee44e69319aab163", size = 40988851, upload-time = "2025-05-08T16:08:33.671Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/e9/7a879c137f7e55b30d75d90ce3eb468197646bc7b443ac036ae3fe109055/scipy-1.15.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3ac07623267feb3ae308487c260ac684b32ea35fd81e12845039952f558047b8", size = 38863011, upload-time = "2025-05-08T16:07:44.039Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d1/226a806bbd69f62ce5ef5f3ffadc35286e9fbc802f606a07eb83bf2359de/scipy-1.15.3-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:6487aa99c2a3d509a5227d9a5e889ff05830a06b2ce08ec30df6d79db5fcd5c5", size = 30266407, upload-time = "2025-05-08T16:07:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/9b/f32d1d6093ab9eeabbd839b0f7619c62e46cc4b7b6dbf05b6e615bbd4400/scipy-1.15.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:50f9e62461c95d933d5c5ef4a1f2ebf9a2b4e83b0db374cb3f1de104d935922e", size = 22540030, upload-time = "2025-05-08T16:07:54.121Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/29/c278f699b095c1a884f29fda126340fcc201461ee8bfea5c8bdb1c7c958b/scipy-1.15.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:14ed70039d182f411ffc74789a16df3835e05dc469b898233a245cdfd7f162cb", size = 25218709, upload-time = "2025-05-08T16:07:58.506Z" },
+    { url = "https://files.pythonhosted.org/packages/24/18/9e5374b617aba742a990581373cd6b68a2945d65cc588482749ef2e64467/scipy-1.15.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a769105537aa07a69468a0eefcd121be52006db61cdd8cac8a0e68980bbb723", size = 34809045, upload-time = "2025-05-08T16:08:03.929Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/fe/9c4361e7ba2927074360856db6135ef4904d505e9b3afbbcb073c4008328/scipy-1.15.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9db984639887e3dffb3928d118145ffe40eff2fa40cb241a306ec57c219ebbbb", size = 36703062, upload-time = "2025-05-08T16:08:09.558Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/038ccfe29d272b30086b25a4960f757f97122cb2ec42e62b460d02fe98e9/scipy-1.15.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:40e54d5c7e7ebf1aa596c374c49fa3135f04648a0caabcb66c52884b943f02b4", size = 36393132, upload-time = "2025-05-08T16:08:15.34Z" },
+    { url = "https://files.pythonhosted.org/packages/10/7e/5c12285452970be5bdbe8352c619250b97ebf7917d7a9a9e96b8a8140f17/scipy-1.15.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5e721fed53187e71d0ccf382b6bf977644c533e506c4d33c3fb24de89f5c3ed5", size = 38979503, upload-time = "2025-05-08T16:08:21.513Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/0a5e5349474e1cbc5757975b21bd4fad0e72ebf138c5592f191646154e06/scipy-1.15.3-cp313-cp313t-win_amd64.whl", hash = "sha256:76ad1fb5f8752eabf0fa02e4cc0336b4e8f021e2d5f061ed37d6d264db35e3ca", size = 40308097, upload-time = "2025-05-08T16:08:27.627Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/75/b4ce781849931fef6fd529afa6b63711d5a733065722d0c3e2724af9e40a/scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec", size = 31613675, upload-time = "2026-02-23T00:16:00.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057, upload-time = "2026-02-23T00:16:09.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032, upload-time = "2026-02-23T00:16:17.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e6/cef1cf3557f0c54954198554a10016b6a03b2ec9e22a4e1df734936bd99c/scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd", size = 22709533, upload-time = "2026-02-23T00:16:25.791Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/60/8804678875fc59362b0fb759ab3ecce1f09c10a735680318ac30da8cd76b/scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c", size = 33062057, upload-time = "2026-02-23T00:16:36.931Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4", size = 35349300, upload-time = "2026-02-23T00:16:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3d/7ccbbdcbb54c8fdc20d3b6930137c782a163fa626f0aef920349873421ba/scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444", size = 35127333, upload-time = "2026-02-23T00:17:01.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/19/f926cb11c42b15ba08e3a71e376d816ac08614f769b4f47e06c3580c836a/scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082", size = 37741314, upload-time = "2026-02-23T00:17:12.576Z" },
+    { url = "https://files.pythonhosted.org/packages/95/da/0d1df507cf574b3f224ccc3d45244c9a1d732c81dcb26b1e8a766ae271a8/scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff", size = 36607512, upload-time = "2026-02-23T00:17:23.424Z" },
+    { url = "https://files.pythonhosted.org/packages/68/7f/bdd79ceaad24b671543ffe0ef61ed8e659440eb683b66f033454dcee90eb/scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d", size = 24599248, upload-time = "2026-02-23T00:17:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -81,6 +81,51 @@ wheels = [
 ]
 
 [[package]]
+name = "cairocffi"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/c5/1a4dc131459e68a173cbdab5fad6b524f53f9c1ef7861b7698e998b837cc/cairocffi-1.7.1.tar.gz", hash = "sha256:2e48ee864884ec4a3a34bfa8c9ab9999f688286eb714a15a43ec9d068c36557b", size = 88096, upload-time = "2024-06-18T10:56:06.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d8/ba13451aa6b745c49536e87b6bf8f629b950e84bd0e8308f7dc6883b67e2/cairocffi-1.7.1-py3-none-any.whl", hash = "sha256:9803a0e11f6c962f3b0ae2ec8ba6ae45e957a146a004697a1ac1bbf16b073b3f", size = 75611, upload-time = "2024-06-18T10:55:59.489Z" },
+]
+
+[[package]]
+name = "cairosvg"
+version = "2.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cairocffi" },
+    { name = "cssselect2" },
+    { name = "defusedxml" },
+    { name = "pillow" },
+    { name = "tinycss2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/b9/5106168bd43d7cd8b7cc2a2ee465b385f14b63f4c092bb89eee2d48c8e67/cairosvg-2.8.2.tar.gz", hash = "sha256:07cbf4e86317b27a92318a4cac2a4bb37a5e9c1b8a27355d06874b22f85bef9f", size = 8398590, upload-time = "2025-05-15T06:56:32.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/48/816bd4aaae93dbf9e408c58598bc32f4a8c65f4b86ab560864cb3ee60adb/cairosvg-2.8.2-py3-none-any.whl", hash = "sha256:eab46dad4674f33267a671dce39b64be245911c901c70d65d2b7b0821e852bf5", size = 45773, upload-time = "2025-05-15T06:56:28.552Z" },
+]
+
+[[package]]
+name = "cclib"
+version = "1.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "periodictable" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/f9/baa541973b7c2dd5b6d2f564284e1fc4307502fb521875150d3a17d8ea84/cclib-1.8.1.tar.gz", hash = "sha256:d10aa2352479fcdaa86cc32055a8ae7f98ce26523ea928944ab2256f0875d605", size = 315050, upload-time = "2024-03-18T16:36:28.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/76/96b7ffc917962e6f74bff1ec850838796f58bedceac6f610834898af6462/cclib-1.8.1-py3-none-any.whl", hash = "sha256:ac86cc5f013b7173c5bc62bfae0637ac83ad34de1ed57a1c7c7fb7b3e512c92f", size = 353649, upload-time = "2024-03-18T16:36:26.996Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -303,6 +348,9 @@ test = [
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
+xyzrender = [
+    { name = "xyzrender" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -327,8 +375,9 @@ requires-dist = [
     { name = "sphinx-sitemap", marker = "extra == 'doc'", specifier = ">=2.5.1" },
     { name = "sphinx-togglebutton", marker = "extra == 'doc'", specifier = ">=0.3.2" },
     { name = "sphinxcontrib-apidoc", marker = "extra == 'doc'", specifier = ">=0.4" },
+    { name = "xyzrender", marker = "extra == 'xyzrender'", specifier = ">=0.1.2" },
 ]
-provides-extras = ["doc", "lint", "neb", "plot", "test"]
+provides-extras = ["doc", "lint", "neb", "plot", "test", "xyzrender"]
 
 [[package]]
 name = "click"
@@ -649,6 +698,19 @@ toml = [
 ]
 
 [[package]]
+name = "cssselect2"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tinycss2" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/20/92eaa6b0aec7189fa4b75c890640e076e9e793095721db69c5c81142c2e1/cssselect2-0.9.0.tar.gz", hash = "sha256:759aa22c216326356f65e62e791d66160a0f9c91d1424e8d8adc5e74dddfc6fb", size = 35595, upload-time = "2026-02-12T17:16:39.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/0e/8459ca4413e1a21a06c97d134bfaf18adfd27cea068813dc0faae06cbf00/cssselect2-0.9.0-py3-none-any.whl", hash = "sha256:6a99e5f91f9a016a304dd929b0966ca464bcfda15177b6fb4a118fc0fb5d9563", size = 15453, upload-time = "2026-02-12T17:16:38.317Z" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -693,6 +755,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
 ]
 
 [[package]]
@@ -829,6 +900,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/40/cc11f378b561a67bea850ab50063366a0d1dd3f6d0a30ce0f874b0ad5664/fonttools-4.61.1-cp314-cp314t-win32.whl", hash = "sha256:aed04cabe26f30c1647ef0e8fbb207516fd40fe9472e9439695f5c6998e60ac5", size = 2335377, upload-time = "2025-12-12T17:31:16.49Z" },
     { url = "https://files.pythonhosted.org/packages/e4/ff/c9a2b66b39f8628531ea58b320d66d951267c98c6a38684daa8f50fb02f8/fonttools-4.61.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2180f14c141d2f0f3da43f3a81bc8aa4684860f6b0e6f9e165a4831f24e6a23b", size = 2400613, upload-time = "2025-12-12T17:31:18.769Z" },
     { url = "https://files.pythonhosted.org/packages/c7/4e/ce75a57ff3aebf6fc1f4e9d508b8e5810618a33d900ad6c19eb30b290b97/fonttools-4.61.1-py3-none-any.whl", hash = "sha256:17d2bf5d541add43822bcf0c43d7d847b160c9bb01d15d5007d84e2217aaa371", size = 1148996, upload-time = "2025-12-12T17:31:21.03Z" },
+]
+
+[[package]]
+name = "graphrc"
+version = "1.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cclib" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "xyzgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/bd/3c8f8c1b8126e9fb314532b0a21fe394b4a1272c7f294d8ff3dd97d91565/graphrc-1.3.5.tar.gz", hash = "sha256:079ff83083bdd968b2940e487182aa194dd2e3192643a134f38365d021ff4693", size = 47022, upload-time = "2025-12-09T17:21:21.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/ea/ead00b34e826da14ec411feee8a2ed2200312265bbf9a6415ca0c97e565d/graphrc-1.3.5-py3-none-any.whl", hash = "sha256:eebe4026a3bebec6ce74f78695e094532e88b43653e76f0a52befe7a60d4987a", size = 44900, upload-time = "2025-12-09T17:21:19.467Z" },
 ]
 
 [[package]]
@@ -1309,86 +1397,16 @@ wheels = [
 [[package]]
 name = "markupsafe"
 version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+source = { registry = "https://download.pytorch.org/whl/cpu" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
-    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
-    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
-    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
-    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
-    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
-    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
-    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
-    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
-    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
-    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
-    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
-    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
-    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
-    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
-    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
-    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
-    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
-    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
-    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
-    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
-    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
-    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
-    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
-    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
-    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
-    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
-    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
-    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
-    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
-    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314-win_amd64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" },
+    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl" },
 ]
 
 [[package]]
@@ -1607,6 +1625,31 @@ wheels = [
 ]
 
 [[package]]
+name = "networkx"
+version = "3.4.2"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.2.6"
 source = { registry = "https://download.pytorch.org/whl/cpu" }
@@ -1782,6 +1825,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/ab/1de9a4f730edde1bdbbc2b8d19f8fa326f036b4f18b2f72cfbea7dc53c26/pbr-7.0.3.tar.gz", hash = "sha256:b46004ec30a5324672683ec848aed9e8fc500b0d261d40a3229c2d2bbfcedc29", size = 135625, upload-time = "2025-11-03T17:04:56.274Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/db/61efa0d08a99f897ef98256b03e563092d36cc38dc4ebe4a85020fe40b31/pbr-7.0.3-py2.py3-none-any.whl", hash = "sha256:ff223894eb1cd271a98076b13d3badff3bb36c424074d26334cd25aebeecea6b", size = 131898, upload-time = "2025-11-03T17:04:54.875Z" },
+]
+
+[[package]]
+name = "periodictable"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pyparsing" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/e4/f2a338abfb5a6b9e2a48dc4acaa9df0bd94126df336ab403178f6a7a901a/periodictable-2.0.2-py3-none-any.whl", hash = "sha256:7d0680baf758715dd66bdac733de82dcb976aa03981fbd6d75a84213fb3b5f86", size = 811077, upload-time = "2024-12-20T02:26:26.165Z" },
 ]
 
 [[package]]
@@ -2244,6 +2300,38 @@ wheels = [
 ]
 
 [[package]]
+name = "rdkit"
+version = "2025.9.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/f0/4637604614dc11abe1a57c4491033e57e96a09400f6b60b64dccd055bc78/rdkit-2025.9.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:129ab527eb4a12d7cc82707a78b5558ba33074894ee86138ad382d486bf3cd72", size = 29515255, upload-time = "2026-02-16T08:48:18.509Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/82/fec87c89c816d66bd6dfa1765dc479f8383135ce9b55664eb52351f72004/rdkit-2025.9.5-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:6ec55e650967cc41f90207f2fa240458e8a689739be97045ebd1ac0cf4bf2985", size = 35242460, upload-time = "2026-02-16T08:48:23.124Z" },
+    { url = "https://files.pythonhosted.org/packages/21/67/aeb84b2da4da12c7ba56cc29e3302259dee1630ff580bee6d04d68669f81/rdkit-2025.9.5-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:b1dd28003a601a65ef5a89013b4a48589edc6c4e94bd98a2752116c6bed6d138", size = 36729523, upload-time = "2026-02-16T08:48:26.893Z" },
+    { url = "https://files.pythonhosted.org/packages/70/64/f6ab4d69f5797c30b50aa0959e0eb257aeedc73fdb29acad432b434bc95f/rdkit-2025.9.5-cp310-cp310-win_amd64.whl", hash = "sha256:c3281d5ba71781409f63f3e08d501a69fe977fcb19742cb2a3905646307aff11", size = 24281514, upload-time = "2026-02-16T08:48:30.177Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e5/aafa2eea493035edc6995b6b99ad5776ca735613344c3468386b72ad4e58/rdkit-2025.9.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:37e33ac1437ae60f8e97901ad0246a69b5ea0c68ac74605cbea85c3913721840", size = 29515614, upload-time = "2026-02-16T08:48:34.565Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c5/79a67fd3fce6e8d087a120c74f49cd0a68ceb441819f09e948d6ab38f579/rdkit-2025.9.5-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:7cea7687aaf73ae6950e730203d7e0eab769e56aa24289aace64ba7ae5b457d1", size = 35237379, upload-time = "2026-02-16T08:48:38.18Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2c/f949c5b8fbc760906bc6555beefbebd505894d50e38fbaa159e5c8301bbc/rdkit-2025.9.5-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7318bc4fb8a1755999aeed43222cd4c95e64795555b84db15ae0cbb7686a254c", size = 36728364, upload-time = "2026-02-16T08:48:42.689Z" },
+    { url = "https://files.pythonhosted.org/packages/73/cf/e2c0d68f2586f1a24e256d6132f73db4b30af3a548a3ffd6a24142414fb9/rdkit-2025.9.5-cp311-cp311-win_amd64.whl", hash = "sha256:14413636c51c46a238ca6d8b652b13d6824f10e4951b6d995cbc7f2e763170b9", size = 24281655, upload-time = "2026-02-16T08:48:46.029Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/6c/55aa888c54cf3aa8c8fb525642c51769e37fd2bcdd924cd35c3cb3678fc1/rdkit-2025.9.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:64f313a8e2993bd7de8c1d72dc268e25c27bcaab31d4217a58528fbcc0ca5195", size = 29560510, upload-time = "2026-02-16T08:48:49.538Z" },
+    { url = "https://files.pythonhosted.org/packages/21/6f/d6420b5343c9b113b41235f3497e4d9fbff9ac5ee7df3be5c6f09f25723e/rdkit-2025.9.5-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:24ab792c9eae49bc0cffe619bcac4ccc91ce61eb09ea68be5a74f29d7671681d", size = 35118879, upload-time = "2026-02-16T08:48:53.36Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/86/5609ddde91431190739919e6c41821b4fcd2a3fcc05dcc4094a666b34796/rdkit-2025.9.5-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:07705d64bf33b832eff1ea8819c0ffe38e079b31ebb194a73e5ae47554910c8b", size = 36663662, upload-time = "2026-02-16T08:48:57.757Z" },
+    { url = "https://files.pythonhosted.org/packages/03/21/1da115389d2eae82364ac5eb4c95c7c57841f2906239257b17af3b8d48f4/rdkit-2025.9.5-cp312-cp312-win_amd64.whl", hash = "sha256:f99b65d3b52d76532ceecb73befae0180e147120972d4054fcd3c66fa71f3a95", size = 24300316, upload-time = "2026-02-16T08:49:01.634Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/08/692d9f44c4dfa1068bfc0d9240dba5f96205b33054367c19c1e4d2448290/rdkit-2025.9.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e31e1924e4d0ce19e5474037875294937bc5835b2f95d2c2c3025d6cd4ec4dfa", size = 29559487, upload-time = "2026-02-16T08:49:05.175Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f3/baffbc78adad2324662d9c72bc132af40506eec2b612f7c07756b970426b/rdkit-2025.9.5-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:158d04129bfdeb2513c49cea208721bc5d6efb6611ba578006f81d3a9807381b", size = 35117644, upload-time = "2026-02-16T08:49:09.343Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c2/41b6344807a63fb8367be2f3a503d13d22d6d905c2254091e1c2004fd3bc/rdkit-2025.9.5-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6fd443a12fc14a8258629d08916d39080a470b839d5a91c2275cc48fe93712f2", size = 36662343, upload-time = "2026-02-16T08:49:13.216Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1e/dad9db005fc843a1ac718e4d09ec2d744e5849b6b453b196a065515b3edd/rdkit-2025.9.5-cp313-cp313-win_amd64.whl", hash = "sha256:957050e2c5b9cf623dc2a82f10847f7f6cebd15ef2edac40cd10120117c9927c", size = 24299076, upload-time = "2026-02-16T08:49:16.746Z" },
+    { url = "https://files.pythonhosted.org/packages/05/da/2be2611623d9d74c5dd7a0720705c9ccd09141d439e642cdeeab9eec935a/rdkit-2025.9.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2ce8f198daa6d81aa1988751cd355ffd6a0b77dc5d58073545785ef0ff5a0c66", size = 29575267, upload-time = "2026-02-16T08:49:20.661Z" },
+    { url = "https://files.pythonhosted.org/packages/53/47/0c0395cae6789c90bb781b92f08f4cbc857adf767f27cb935397bd892779/rdkit-2025.9.5-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:53325659acca69827f42f93cfdb056286cafb824fa6f7a94ea07628f35777c98", size = 35150791, upload-time = "2026-02-16T08:49:24.321Z" },
+    { url = "https://files.pythonhosted.org/packages/65/c6/c1a4796ac4b428829c8a388f8e4096adfb0963226b2b45eeb2676b92b7e5/rdkit-2025.9.5-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:94b6173fb9c7701d2479018a69c057429f2507a4cfe5ee1f2e430b0f8b0d7afc", size = 36674240, upload-time = "2026-02-16T08:49:29.236Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/02/22537010d4959a3706ccf2ea8413be6b45fca684b3c3628924b05dc46e8f/rdkit-2025.9.5-cp314-cp314-win_amd64.whl", hash = "sha256:945d2bc7b1677d2a138a4c65eb42370ab20ac4db0f969d64c0176683371251e9", size = 24775860, upload-time = "2026-02-16T08:49:32.94Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2274,8 +2362,8 @@ wheels = [
 
 [[package]]
 name = "rgpycrumbs"
-version = "1.0.1"
-source = { git = "https://github.com/HaoZeke/rgpycrumbs#32def444ba3381ee5507eb6018bbe66bfdaf8e40" }
+version = "1.2.0"
+source = { git = "https://github.com/HaoZeke/rgpycrumbs#e963e12d87d4a956810df46815707eebc2e08a90" }
 dependencies = [
     { name = "click" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
@@ -2937,6 +3025,18 @@ wheels = [
 ]
 
 [[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3045,6 +3145,15 @@ wheels = [
 ]
 
 [[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
 name = "wheel"
 version = "0.46.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3054,6 +3163,40 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/24/a2eb353a6edac9a0303977c4cb048134959dd2a51b48a269dfc9dde00c8a/wheel-0.46.3.tar.gz", hash = "sha256:e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803", size = 60605, upload-time = "2026-01-22T12:39:49.136Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/22/b76d483683216dde3d67cba61fb2444be8d5be289bf628c13fc0fd90e5f9/wheel-0.46.3-py3-none-any.whl", hash = "sha256:4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d", size = 30557, upload-time = "2026-01-22T12:39:48.099Z" },
+]
+
+[[package]]
+name = "xyzgraph"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "networkx", version = "3.4.2", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "rdkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/ec/f82fe482987523cb861561f27ce9cee3ae99c0cb8c4fec07440453f80d4b/xyzgraph-1.6.1.tar.gz", hash = "sha256:e005eacf55a73f5208b99c7665ba317709b9274374b511062881f761a3eaeef1", size = 142683, upload-time = "2026-02-23T10:16:28.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/ab/5867ddf13cc6c31286324cfdc4e5899ef6bba6b1eda6e551a1c9c936e7a4/xyzgraph-1.6.1-py3-none-any.whl", hash = "sha256:8d3b1b96eb9410698c3609baa88f9016e37d2586fe8db89e3f35e914ecdf3049", size = 106653, upload-time = "2026-02-23T10:16:26.887Z" },
+]
+
+[[package]]
+name = "xyzrender"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cairosvg" },
+    { name = "cclib" },
+    { name = "graphrc" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pillow" },
+    { name = "xyzgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/db/9e264a4ceeb375ed135bdd922d15713c00cf20cde5074d89d62e8f421937/xyzrender-0.1.2.tar.gz", hash = "sha256:de8644fbe90cbd02c135ec1946908acd55a82dc6a7abbf634f5790f7591e8695", size = 36696, upload-time = "2026-02-22T19:58:45.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/c7/6a2f9e08253ed6ec56647736cee47518da0a4a568a82565f04ffe6af3e85/xyzrender-0.1.2-py3-none-any.whl", hash = "sha256:adfcf9954c50e30df71b125d63ad5e4393479a78cd6c0f94453de848681e82c9", size = 32401, upload-time = "2026-02-22T19:58:44.501Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -31,7 +31,7 @@ version = "3.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -113,7 +113,7 @@ name = "cclib"
 version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "periodictable" },
@@ -309,7 +309,7 @@ wheels = [
 name = "chemparseplot"
 source = { editable = "." }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pint", version = "0.24.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pint", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -397,7 +397,7 @@ version = "1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
 ]
@@ -409,9 +409,10 @@ wheels = [
 [[package]]
 name = "colorama"
 version = "0.4.6"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6" },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
@@ -431,7 +432,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -908,9 +909,9 @@ version = "1.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cclib" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "xyzgraph" },
 ]
@@ -984,7 +985,7 @@ name = "h5py"
 version = "3.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/6a/0d79de0b025aa85dc8864de8e97659c94cf3d23148394a954dc5ca52f8c8/h5py-3.15.1.tar.gz", hash = "sha256:c86e3ed45c4473564de55aa83b6fc9e5ead86578773dfbd93047380042e26b69", size = 426236, upload-time = "2025-10-16T10:35:27.404Z" }
@@ -1172,12 +1173,13 @@ wheels = [
 [[package]]
 name = "jinja2"
 version = "3.1.6"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/jinja2-3.1.6-py3-none-any.whl" },
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -1397,16 +1399,86 @@ wheels = [
 [[package]]
 name = "markupsafe"
 version = "3.0.3"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl" },
-    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314-win_amd64.whl" },
-    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl" },
-    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl" },
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -1419,7 +1491,7 @@ dependencies = [
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "pillow" },
@@ -1627,91 +1699,91 @@ wheels = [
 [[package]]
 name = "networkx"
 version = "3.4.2"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f" },
+    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263, upload-time = "2024-10-21T12:39:36.247Z" },
 ]
 
 [[package]]
 name = "networkx"
 version = "3.6.1"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.12'",
     "python_full_version == '3.11.*'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762" },
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
 name = "numpy"
 version = "2.2.6"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3e/ed6db5be21ce87955c0cbd3009f2803f59fa08df21b5df06862e2d8e2bdd/numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb" },
-    { url = "https://files.pythonhosted.org/packages/22/c2/4b9221495b2a132cc9d2eb862e21d42a009f5a60e45fc44b00118c174bff/numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90" },
-    { url = "https://files.pythonhosted.org/packages/fd/77/dc2fcfc66943c6410e2bf598062f5959372735ffda175b39906d54f02349/numpy-2.2.6-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:37e990a01ae6ec7fe7fa1c26c55ecb672dd98b19c3d0e1d1f326fa13cb38d163" },
-    { url = "https://files.pythonhosted.org/packages/7a/4f/1cb5fdc353a5f5cc7feb692db9b8ec2c3d6405453f982435efc52561df58/numpy-2.2.6-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:5a6429d4be8ca66d889b7cf70f536a397dc45ba6faeb5f8c5427935d9592e9cf" },
-    { url = "https://files.pythonhosted.org/packages/eb/17/96a3acd228cec142fcb8723bd3cc39c2a474f7dcf0a5d16731980bcafa95/numpy-2.2.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efd28d4e9cd7d7a8d39074a4d44c63eda73401580c5c76acda2ce969e0a38e83" },
-    { url = "https://files.pythonhosted.org/packages/b4/63/3de6a34ad7ad6646ac7d2f55ebc6ad439dbbf9c4370017c50cf403fb19b5/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc7b73d02efb0e18c000e9ad8b83480dfcd5dfd11065997ed4c6747470ae8915" },
-    { url = "https://files.pythonhosted.org/packages/07/b6/89d837eddef52b3d0cec5c6ba0456c1bf1b9ef6a6672fc2b7873c3ec4e2e/numpy-2.2.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:74d4531beb257d2c3f4b261bfb0fc09e0f9ebb8842d82a7b4209415896adc680" },
-    { url = "https://files.pythonhosted.org/packages/01/c8/dc6ae86e3c61cfec1f178e5c9f7858584049b6093f843bca541f94120920/numpy-2.2.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8fc377d995680230e83241d8a96def29f204b5782f371c532579b4f20607a289" },
-    { url = "https://files.pythonhosted.org/packages/5b/c5/0064b1b7e7c89137b471ccec1fd2282fceaae0ab3a9550f2568782d80357/numpy-2.2.6-cp310-cp310-win32.whl", hash = "sha256:b093dd74e50a8cba3e873868d9e93a85b78e0daf2e98c6797566ad8044e8363d" },
-    { url = "https://files.pythonhosted.org/packages/a3/dd/4b822569d6b96c39d1215dbae0582fd99954dcbcf0c1a13c61783feaca3f/numpy-2.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:f0fd6321b839904e15c46e0d257fdd101dd7f530fe03fd6359c1ea63738703f3" },
-    { url = "https://files.pythonhosted.org/packages/da/a8/4f83e2aa666a9fbf56d6118faaaf5f1974d456b1823fda0a176eff722839/numpy-2.2.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f9f1adb22318e121c5c69a09142811a201ef17ab257a1e66ca3025065b7f53ae" },
-    { url = "https://files.pythonhosted.org/packages/b3/2b/64e1affc7972decb74c9e29e5649fac940514910960ba25cd9af4488b66c/numpy-2.2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c820a93b0255bc360f53eca31a0e676fd1101f673dda8da93454a12e23fc5f7a" },
-    { url = "https://files.pythonhosted.org/packages/4a/9f/0121e375000b5e50ffdd8b25bf78d8e1a5aa4cca3f185d41265198c7b834/numpy-2.2.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3d70692235e759f260c3d837193090014aebdf026dfd167834bcba43e30c2a42" },
-    { url = "https://files.pythonhosted.org/packages/31/0d/b48c405c91693635fbe2dcd7bc84a33a602add5f63286e024d3b6741411c/numpy-2.2.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:481b49095335f8eed42e39e8041327c05b0f6f4780488f61286ed3c01368d491" },
-    { url = "https://files.pythonhosted.org/packages/52/b8/7f0554d49b565d0171eab6e99001846882000883998e7b7d9f0d98b1f934/numpy-2.2.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b64d8d4d17135e00c8e346e0a738deb17e754230d7e0810ac5012750bbd85a5a" },
-    { url = "https://files.pythonhosted.org/packages/b3/dd/2238b898e51bd6d389b7389ffb20d7f4c10066d80351187ec8e303a5a475/numpy-2.2.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba10f8411898fc418a521833e014a77d3ca01c15b0c6cdcce6a0d2897e6dbbdf" },
-    { url = "https://files.pythonhosted.org/packages/83/6c/44d0325722cf644f191042bf47eedad61c1e6df2432ed65cbe28509d404e/numpy-2.2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bd48227a919f1bafbdda0583705e547892342c26fb127219d60a5c36882609d1" },
-    { url = "https://files.pythonhosted.org/packages/ae/9d/81e8216030ce66be25279098789b665d49ff19eef08bfa8cb96d4957f422/numpy-2.2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9551a499bf125c1d4f9e250377c1ee2eddd02e01eac6644c080162c0c51778ab" },
-    { url = "https://files.pythonhosted.org/packages/6a/fd/e19617b9530b031db51b0926eed5345ce8ddc669bb3bc0044b23e275ebe8/numpy-2.2.6-cp311-cp311-win32.whl", hash = "sha256:0678000bb9ac1475cd454c6b8c799206af8107e310843532b04d49649c717a47" },
-    { url = "https://files.pythonhosted.org/packages/31/0a/f354fb7176b81747d870f7991dc763e157a934c717b67b58456bc63da3df/numpy-2.2.6-cp311-cp311-win_amd64.whl", hash = "sha256:e8213002e427c69c45a52bbd94163084025f533a55a59d6f9c5b820774ef3303" },
-    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff" },
-    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c" },
-    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3" },
-    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282" },
-    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87" },
-    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249" },
-    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49" },
-    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de" },
-    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4" },
-    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2" },
-    { url = "https://files.pythonhosted.org/packages/f9/5c/6657823f4f594f72b5471f1db1ab12e26e890bb2e41897522d134d2a3e81/numpy-2.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0811bb762109d9708cca4d0b13c4f67146e3c3b7cf8d34018c722adb2d957c84" },
-    { url = "https://files.pythonhosted.org/packages/dc/9e/14520dc3dadf3c803473bd07e9b2bd1b69bc583cb2497b47000fed2fa92f/numpy-2.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:287cc3162b6f01463ccd86be154f284d0893d2b3ed7292439ea97eafa8170e0b" },
-    { url = "https://files.pythonhosted.org/packages/4f/06/7e96c57d90bebdce9918412087fc22ca9851cceaf5567a45c1f404480e9e/numpy-2.2.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f1372f041402e37e5e633e586f62aa53de2eac8d98cbfb822806ce4bbefcb74d" },
-    { url = "https://files.pythonhosted.org/packages/73/ed/63d920c23b4289fdac96ddbdd6132e9427790977d5457cd132f18e76eae0/numpy-2.2.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:55a4d33fa519660d69614a9fad433be87e5252f4b03850642f88993f7b2ca566" },
-    { url = "https://files.pythonhosted.org/packages/85/c5/e19c8f99d83fd377ec8c7e0cf627a8049746da54afc24ef0a0cb73d5dfb5/numpy-2.2.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f92729c95468a2f4f15e9bb94c432a9229d0d50de67304399627a943201baa2f" },
-    { url = "https://files.pythonhosted.org/packages/19/49/4df9123aafa7b539317bf6d342cb6d227e49f7a35b99c287a6109b13dd93/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc23a79bfabc5d056d106f9befb8d50c31ced2fbc70eedb8155aec74a45798f" },
-    { url = "https://files.pythonhosted.org/packages/b2/6c/04b5f47f4f32f7c2b0e7260442a8cbcf8168b0e1a41ff1495da42f42a14f/numpy-2.2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3143e4451880bed956e706a3220b4e5cf6172ef05fcc397f6f36a550b1dd868" },
-    { url = "https://files.pythonhosted.org/packages/17/0a/5cd92e352c1307640d5b6fec1b2ffb06cd0dabe7d7b8227f97933d378422/numpy-2.2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4f13750ce79751586ae2eb824ba7e1e8dba64784086c98cdbbcc6a42112ce0d" },
-    { url = "https://files.pythonhosted.org/packages/f0/3b/5cba2b1d88760ef86596ad0f3d484b1cbff7c115ae2429678465057c5155/numpy-2.2.6-cp313-cp313-win32.whl", hash = "sha256:5beb72339d9d4fa36522fc63802f469b13cdbe4fdab4a288f0c441b74272ebfd" },
-    { url = "https://files.pythonhosted.org/packages/cb/3b/d58c12eafcb298d4e6d0d40216866ab15f59e55d148a5658bb3132311fcf/numpy-2.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b0544343a702fa80c95ad5d3d608ea3599dd54d4632df855e4c8d24eb6ecfa1c" },
-    { url = "https://files.pythonhosted.org/packages/6b/9e/4bf918b818e516322db999ac25d00c75788ddfd2d2ade4fa66f1f38097e1/numpy-2.2.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0bca768cd85ae743b2affdc762d617eddf3bcf8724435498a1e80132d04879e6" },
-    { url = "https://files.pythonhosted.org/packages/61/66/d2de6b291507517ff2e438e13ff7b1e2cdbdb7cb40b3ed475377aece69f9/numpy-2.2.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fc0c5673685c508a142ca65209b4e79ed6740a4ed6b2267dbba90f34b0b3cfda" },
-    { url = "https://files.pythonhosted.org/packages/e4/25/480387655407ead912e28ba3a820bc69af9adf13bcbe40b299d454ec011f/numpy-2.2.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:5bd4fc3ac8926b3819797a7c0e2631eb889b4118a9898c84f585a54d475b7e40" },
-    { url = "https://files.pythonhosted.org/packages/aa/4a/6e313b5108f53dcbf3aca0c0f3e9c92f4c10ce57a0a721851f9785872895/numpy-2.2.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:fee4236c876c4e8369388054d02d0e9bb84821feb1a64dd59e137e6511a551f8" },
-    { url = "https://files.pythonhosted.org/packages/b7/30/172c2d5c4be71fdf476e9de553443cf8e25feddbe185e0bd88b096915bcc/numpy-2.2.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1dda9c7e08dc141e0247a5b8f49cf05984955246a327d4c48bda16821947b2f" },
-    { url = "https://files.pythonhosted.org/packages/12/fb/9e743f8d4e4d3c710902cf87af3512082ae3d43b945d5d16563f26ec251d/numpy-2.2.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f447e6acb680fd307f40d3da4852208af94afdfab89cf850986c3ca00562f4fa" },
-    { url = "https://files.pythonhosted.org/packages/12/75/ee20da0e58d3a66f204f38916757e01e33a9737d0b22373b3eb5a27358f9/numpy-2.2.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:389d771b1623ec92636b0786bc4ae56abafad4a4c513d36a55dce14bd9ce8571" },
-    { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1" },
-    { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff" },
-    { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06" },
-    { url = "https://files.pythonhosted.org/packages/9e/3b/d94a75f4dbf1ef5d321523ecac21ef23a3cd2ac8b78ae2aac40873590229/numpy-2.2.6-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0b605b275d7bd0c640cad4e5d30fa701a8d59302e127e5f79138ad62762c3e3d" },
-    { url = "https://files.pythonhosted.org/packages/17/f4/09b2fa1b58f0fb4f7c7963a1649c64c4d315752240377ed74d9cd878f7b5/numpy-2.2.6-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:7befc596a7dc9da8a337f79802ee8adb30a552a94f792b9c9d18c840055907db" },
-    { url = "https://files.pythonhosted.org/packages/af/30/feba75f143bdc868a1cc3f44ccfa6c4b9ec522b36458e738cd00f67b573f/numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543" },
-    { url = "https://files.pythonhosted.org/packages/37/48/ac2a9584402fb6c0cd5b5d1a91dcf176b15760130dd386bbafdbfe3640bf/numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00" },
+    { url = "https://files.pythonhosted.org/packages/9a/3e/ed6db5be21ce87955c0cbd3009f2803f59fa08df21b5df06862e2d8e2bdd/numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb", size = 21165245, upload-time = "2025-05-17T21:27:58.555Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c2/4b9221495b2a132cc9d2eb862e21d42a009f5a60e45fc44b00118c174bff/numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90", size = 14360048, upload-time = "2025-05-17T21:28:21.406Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/dc2fcfc66943c6410e2bf598062f5959372735ffda175b39906d54f02349/numpy-2.2.6-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:37e990a01ae6ec7fe7fa1c26c55ecb672dd98b19c3d0e1d1f326fa13cb38d163", size = 5340542, upload-time = "2025-05-17T21:28:30.931Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4f/1cb5fdc353a5f5cc7feb692db9b8ec2c3d6405453f982435efc52561df58/numpy-2.2.6-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:5a6429d4be8ca66d889b7cf70f536a397dc45ba6faeb5f8c5427935d9592e9cf", size = 6878301, upload-time = "2025-05-17T21:28:41.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/17/96a3acd228cec142fcb8723bd3cc39c2a474f7dcf0a5d16731980bcafa95/numpy-2.2.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efd28d4e9cd7d7a8d39074a4d44c63eda73401580c5c76acda2ce969e0a38e83", size = 14297320, upload-time = "2025-05-17T21:29:02.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/63/3de6a34ad7ad6646ac7d2f55ebc6ad439dbbf9c4370017c50cf403fb19b5/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc7b73d02efb0e18c000e9ad8b83480dfcd5dfd11065997ed4c6747470ae8915", size = 16801050, upload-time = "2025-05-17T21:29:27.675Z" },
+    { url = "https://files.pythonhosted.org/packages/07/b6/89d837eddef52b3d0cec5c6ba0456c1bf1b9ef6a6672fc2b7873c3ec4e2e/numpy-2.2.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:74d4531beb257d2c3f4b261bfb0fc09e0f9ebb8842d82a7b4209415896adc680", size = 15807034, upload-time = "2025-05-17T21:29:51.102Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c8/dc6ae86e3c61cfec1f178e5c9f7858584049b6093f843bca541f94120920/numpy-2.2.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8fc377d995680230e83241d8a96def29f204b5782f371c532579b4f20607a289", size = 18614185, upload-time = "2025-05-17T21:30:18.703Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c5/0064b1b7e7c89137b471ccec1fd2282fceaae0ab3a9550f2568782d80357/numpy-2.2.6-cp310-cp310-win32.whl", hash = "sha256:b093dd74e50a8cba3e873868d9e93a85b78e0daf2e98c6797566ad8044e8363d", size = 6527149, upload-time = "2025-05-17T21:30:29.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/dd/4b822569d6b96c39d1215dbae0582fd99954dcbcf0c1a13c61783feaca3f/numpy-2.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:f0fd6321b839904e15c46e0d257fdd101dd7f530fe03fd6359c1ea63738703f3", size = 12904620, upload-time = "2025-05-17T21:30:48.994Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a8/4f83e2aa666a9fbf56d6118faaaf5f1974d456b1823fda0a176eff722839/numpy-2.2.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f9f1adb22318e121c5c69a09142811a201ef17ab257a1e66ca3025065b7f53ae", size = 21176963, upload-time = "2025-05-17T21:31:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2b/64e1affc7972decb74c9e29e5649fac940514910960ba25cd9af4488b66c/numpy-2.2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c820a93b0255bc360f53eca31a0e676fd1101f673dda8da93454a12e23fc5f7a", size = 14406743, upload-time = "2025-05-17T21:31:41.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9f/0121e375000b5e50ffdd8b25bf78d8e1a5aa4cca3f185d41265198c7b834/numpy-2.2.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3d70692235e759f260c3d837193090014aebdf026dfd167834bcba43e30c2a42", size = 5352616, upload-time = "2025-05-17T21:31:50.072Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0d/b48c405c91693635fbe2dcd7bc84a33a602add5f63286e024d3b6741411c/numpy-2.2.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:481b49095335f8eed42e39e8041327c05b0f6f4780488f61286ed3c01368d491", size = 6889579, upload-time = "2025-05-17T21:32:01.712Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/7f0554d49b565d0171eab6e99001846882000883998e7b7d9f0d98b1f934/numpy-2.2.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b64d8d4d17135e00c8e346e0a738deb17e754230d7e0810ac5012750bbd85a5a", size = 14312005, upload-time = "2025-05-17T21:32:23.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/dd/2238b898e51bd6d389b7389ffb20d7f4c10066d80351187ec8e303a5a475/numpy-2.2.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba10f8411898fc418a521833e014a77d3ca01c15b0c6cdcce6a0d2897e6dbbdf", size = 16821570, upload-time = "2025-05-17T21:32:47.991Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6c/44d0325722cf644f191042bf47eedad61c1e6df2432ed65cbe28509d404e/numpy-2.2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bd48227a919f1bafbdda0583705e547892342c26fb127219d60a5c36882609d1", size = 15818548, upload-time = "2025-05-17T21:33:11.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/9d/81e8216030ce66be25279098789b665d49ff19eef08bfa8cb96d4957f422/numpy-2.2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9551a499bf125c1d4f9e250377c1ee2eddd02e01eac6644c080162c0c51778ab", size = 18620521, upload-time = "2025-05-17T21:33:39.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/e19617b9530b031db51b0926eed5345ce8ddc669bb3bc0044b23e275ebe8/numpy-2.2.6-cp311-cp311-win32.whl", hash = "sha256:0678000bb9ac1475cd454c6b8c799206af8107e310843532b04d49649c717a47", size = 6525866, upload-time = "2025-05-17T21:33:50.273Z" },
+    { url = "https://files.pythonhosted.org/packages/31/0a/f354fb7176b81747d870f7991dc763e157a934c717b67b58456bc63da3df/numpy-2.2.6-cp311-cp311-win_amd64.whl", hash = "sha256:e8213002e427c69c45a52bbd94163084025f533a55a59d6f9c5b820774ef3303", size = 12907455, upload-time = "2025-05-17T21:34:09.135Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff", size = 20875348, upload-time = "2025-05-17T21:34:39.648Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c", size = 14119362, upload-time = "2025-05-17T21:35:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3", size = 5084103, upload-time = "2025-05-17T21:35:10.622Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282", size = 6625382, upload-time = "2025-05-17T21:35:21.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87", size = 14018462, upload-time = "2025-05-17T21:35:42.174Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249", size = 16527618, upload-time = "2025-05-17T21:36:06.711Z" },
+    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49", size = 15505511, upload-time = "2025-05-17T21:36:29.965Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de", size = 18313783, upload-time = "2025-05-17T21:36:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4", size = 6246506, upload-time = "2025-05-17T21:37:07.368Z" },
+    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2", size = 12614190, upload-time = "2025-05-17T21:37:26.213Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5c/6657823f4f594f72b5471f1db1ab12e26e890bb2e41897522d134d2a3e81/numpy-2.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0811bb762109d9708cca4d0b13c4f67146e3c3b7cf8d34018c722adb2d957c84", size = 20867828, upload-time = "2025-05-17T21:37:56.699Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9e/14520dc3dadf3c803473bd07e9b2bd1b69bc583cb2497b47000fed2fa92f/numpy-2.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:287cc3162b6f01463ccd86be154f284d0893d2b3ed7292439ea97eafa8170e0b", size = 14143006, upload-time = "2025-05-17T21:38:18.291Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/06/7e96c57d90bebdce9918412087fc22ca9851cceaf5567a45c1f404480e9e/numpy-2.2.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f1372f041402e37e5e633e586f62aa53de2eac8d98cbfb822806ce4bbefcb74d", size = 5076765, upload-time = "2025-05-17T21:38:27.319Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ed/63d920c23b4289fdac96ddbdd6132e9427790977d5457cd132f18e76eae0/numpy-2.2.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:55a4d33fa519660d69614a9fad433be87e5252f4b03850642f88993f7b2ca566", size = 6617736, upload-time = "2025-05-17T21:38:38.141Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c5/e19c8f99d83fd377ec8c7e0cf627a8049746da54afc24ef0a0cb73d5dfb5/numpy-2.2.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f92729c95468a2f4f15e9bb94c432a9229d0d50de67304399627a943201baa2f", size = 14010719, upload-time = "2025-05-17T21:38:58.433Z" },
+    { url = "https://files.pythonhosted.org/packages/19/49/4df9123aafa7b539317bf6d342cb6d227e49f7a35b99c287a6109b13dd93/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc23a79bfabc5d056d106f9befb8d50c31ced2fbc70eedb8155aec74a45798f", size = 16526072, upload-time = "2025-05-17T21:39:22.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6c/04b5f47f4f32f7c2b0e7260442a8cbcf8168b0e1a41ff1495da42f42a14f/numpy-2.2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3143e4451880bed956e706a3220b4e5cf6172ef05fcc397f6f36a550b1dd868", size = 15503213, upload-time = "2025-05-17T21:39:45.865Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0a/5cd92e352c1307640d5b6fec1b2ffb06cd0dabe7d7b8227f97933d378422/numpy-2.2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4f13750ce79751586ae2eb824ba7e1e8dba64784086c98cdbbcc6a42112ce0d", size = 18316632, upload-time = "2025-05-17T21:40:13.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3b/5cba2b1d88760ef86596ad0f3d484b1cbff7c115ae2429678465057c5155/numpy-2.2.6-cp313-cp313-win32.whl", hash = "sha256:5beb72339d9d4fa36522fc63802f469b13cdbe4fdab4a288f0c441b74272ebfd", size = 6244532, upload-time = "2025-05-17T21:43:46.099Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/3b/d58c12eafcb298d4e6d0d40216866ab15f59e55d148a5658bb3132311fcf/numpy-2.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b0544343a702fa80c95ad5d3d608ea3599dd54d4632df855e4c8d24eb6ecfa1c", size = 12610885, upload-time = "2025-05-17T21:44:05.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/9e/4bf918b818e516322db999ac25d00c75788ddfd2d2ade4fa66f1f38097e1/numpy-2.2.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0bca768cd85ae743b2affdc762d617eddf3bcf8724435498a1e80132d04879e6", size = 20963467, upload-time = "2025-05-17T21:40:44Z" },
+    { url = "https://files.pythonhosted.org/packages/61/66/d2de6b291507517ff2e438e13ff7b1e2cdbdb7cb40b3ed475377aece69f9/numpy-2.2.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fc0c5673685c508a142ca65209b4e79ed6740a4ed6b2267dbba90f34b0b3cfda", size = 14225144, upload-time = "2025-05-17T21:41:05.695Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/25/480387655407ead912e28ba3a820bc69af9adf13bcbe40b299d454ec011f/numpy-2.2.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:5bd4fc3ac8926b3819797a7c0e2631eb889b4118a9898c84f585a54d475b7e40", size = 5200217, upload-time = "2025-05-17T21:41:15.903Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4a/6e313b5108f53dcbf3aca0c0f3e9c92f4c10ce57a0a721851f9785872895/numpy-2.2.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:fee4236c876c4e8369388054d02d0e9bb84821feb1a64dd59e137e6511a551f8", size = 6712014, upload-time = "2025-05-17T21:41:27.321Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/30/172c2d5c4be71fdf476e9de553443cf8e25feddbe185e0bd88b096915bcc/numpy-2.2.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1dda9c7e08dc141e0247a5b8f49cf05984955246a327d4c48bda16821947b2f", size = 14077935, upload-time = "2025-05-17T21:41:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fb/9e743f8d4e4d3c710902cf87af3512082ae3d43b945d5d16563f26ec251d/numpy-2.2.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f447e6acb680fd307f40d3da4852208af94afdfab89cf850986c3ca00562f4fa", size = 16600122, upload-time = "2025-05-17T21:42:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/12/75/ee20da0e58d3a66f204f38916757e01e33a9737d0b22373b3eb5a27358f9/numpy-2.2.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:389d771b1623ec92636b0786bc4ae56abafad4a4c513d36a55dce14bd9ce8571", size = 15586143, upload-time = "2025-05-17T21:42:37.464Z" },
+    { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260, upload-time = "2025-05-17T21:43:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225, upload-time = "2025-05-17T21:43:16.254Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374, upload-time = "2025-05-17T21:43:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/3b/d94a75f4dbf1ef5d321523ecac21ef23a3cd2ac8b78ae2aac40873590229/numpy-2.2.6-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0b605b275d7bd0c640cad4e5d30fa701a8d59302e127e5f79138ad62762c3e3d", size = 21040391, upload-time = "2025-05-17T21:44:35.948Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f4/09b2fa1b58f0fb4f7c7963a1649c64c4d315752240377ed74d9cd878f7b5/numpy-2.2.6-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:7befc596a7dc9da8a337f79802ee8adb30a552a94f792b9c9d18c840055907db", size = 6786754, upload-time = "2025-05-17T21:44:47.446Z" },
+    { url = "https://files.pythonhosted.org/packages/af/30/feba75f143bdc868a1cc3f44ccfa6c4b9ec522b36458e738cd00f67b573f/numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543", size = 16643476, upload-time = "2025-05-17T21:45:11.871Z" },
+    { url = "https://files.pythonhosted.org/packages/37/48/ac2a9584402fb6c0cd5b5d1a91dcf176b15760130dd386bbafdbfe3640bf/numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00", size = 12812666, upload-time = "2025-05-17T21:45:31.426Z" },
 ]
 
 [[package]]
@@ -1832,7 +1904,7 @@ name = "periodictable"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyparsing" },
 ]
@@ -2304,7 +2376,7 @@ name = "rdkit"
 version = "2025.9.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow" },
 ]
@@ -2366,7 +2438,7 @@ version = "1.2.0"
 source = { git = "https://github.com/HaoZeke/rgpycrumbs#e963e12d87d4a956810df46815707eebc2e08a90" }
 dependencies = [
     { name = "click" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "rich" },
 ]
@@ -2549,7 +2621,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -3121,9 +3193,10 @@ wheels = [
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/typing_extensions-4.15.0-py3-none-any.whl" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]
@@ -3170,9 +3243,9 @@ name = "xyzgraph"
 version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "networkx", version = "3.4.2", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "rdkit" },
 ]
@@ -3189,7 +3262,7 @@ dependencies = [
     { name = "cairosvg" },
     { name = "cclib" },
     { name = "graphrc" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow" },
     { name = "xyzgraph" },


### PR DESCRIPTION
## Summary

- Adds a generic `parse.trajectory` module for NEB trajectories readable by ASE (extxyz, .traj, etc.), replacing the ChemGP-specific naming
- Extracts duplicated NEB algorithms (synthetic gradient projection, landscape DataFrame construction, RMSD coordinate calculation) into a shared `parse.neb_utils` module used by both `eon` and `trajectory` parsers
- Adds HDF5 NEB reader (`parse.trajectory.hdf5`) for ChemGP Julia output -- reads `neb_result.h5` and `neb_history.h5` with pre-computed `f_para` and `rxn_coord`
- Adds `neb` optional-dependency extra (`ase`, `h5py`, `polars`) to pyproject.toml and updates CI so tests run rather than silently skip

## Changes

- `parse/chemgp/` -> `parse/trajectory/` (generic naming for pyopensci review)
- `parse/neb_utils.py` -- shared utilities, eliminates DRY violations between eon and trajectory parsers
- `parse/eon/neb.py` -- refactored to use shared utilities
- `parse/trajectory/hdf5.py` -- HDF5 reader for ChemGP NEB output (result + history files)
- `tests/conftest.py` -- environment-based test skipping matching rgpycrumbs pattern
- `tests/parse/test_neb_utils.py` + `tests/parse/test_trajectory_neb.py` + `tests/parse/test_trajectory_hdf5.py` -- 67 tests total
- API doc pages for `trajectory`, `trajectory.hdf5`, `eon`, and `neb_utils` modules
- Towncrier changelog fragment
- CI updated with `fail-fast: false`

## Checklist

- [x] All 67 tests pass locally (`uv run --all-extras pytest tests/`)
- [x] NEB tests correctly skip when ase/polars/h5py unavailable
- [x] Smoke test with real ChemGP neb_result.h5 (HCN, 10 images)
- [ ] CI passes on all Python versions (3.10, 3.11, 3.12)

Companion PR: HaoZeke/rgpycrumbs#39 (import path update + hdf5 source)